### PR TITLE
Add /runs/:id route

### DIFF
--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -1,0 +1,12 @@
+import { useParams } from '@remix-run/react'
+
+import { Demo } from 'app/components/Demo'
+
+export default function RunByIdPage() {
+  const params = useParams()
+  return (
+    <Demo>
+      <span className="text-5xl">Run Page ID = {params.id}</span>
+    </Demo>
+  )
+}


### PR DESCRIPTION
## Description

Adds the `/runs/:id` route to the frontend.

## Demo

<img width="1728" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/2efe8d55-2f95-4e4f-83e1-f9bb9339ed18">
