### PR TITLE
Fix naming from FAQ to API

### DIFF
--- a/frontend/packages/data-portal/app/components/Layout/ToolsDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/Layout/ToolsDropdown.tsx
@@ -6,7 +6,7 @@ export function ToolsDropdown({ className }: { className?: string }) {
   return (
     <MenuDropdown className={className} title={i18n.tools}>
       <MenuItemLink to="https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html">
-        {i18n.faq}
+        {i18n.api}
       </MenuItemLink>
 
       <MenuItemLink to="https://chanzuckerberg.github.io/cryoet-data-portal/cryoet_data_portal_docsite_napari.html">


### PR DESCRIPTION
The link to the API was incorrectly labeled as "FAQ"; this PR fixes that and should resolve https://github.com/chanzuckerberg/cryoet-data-portal/issues/151.  (The correct FAQ is linked under the "About & Help" section).