### PR TITLE
Update AWS download command

### DIFF
--- a/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
+++ b/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
@@ -24,7 +24,7 @@ export function AWSDownloadTab() {
     .with(['runs', DownloadConfig.AllAnnotations], () => s3AnnotationsPrefix)
     .otherwise(() => s3TomogramPrefix)
 
-  const awsCommand = `aws s3 sync ${s3Path} .`
+  const awsCommand = `aws s3 --no-sign-request sync ${s3Path} .`
 
   return (
     <div className="py-sds-xl">

--- a/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
+++ b/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
@@ -24,7 +24,8 @@ export function AWSDownloadTab() {
     .with(['runs', DownloadConfig.AllAnnotations], () => s3AnnotationsPrefix)
     .otherwise(() => s3TomogramPrefix)
 
-  const awsCommand = `aws s3 --no-sign-request sync ${s3Path} .`
+  const destinationPath = s3Path?.replace(/\/$/, '').split('/').pop()
+  const awsCommand = `aws s3 --no-sign-request sync ${s3Path} ${destinationPath}`
 
   return (
     <div className="py-sds-xl">


### PR DESCRIPTION
Adds `--no-sign-request` flag so that AWS does not attempt to load credentials, as intended in https://github.com/chanzuckerberg/cryoet-data-portal/issues/59#issuecomment-1796480671.  Also adds a destination folder. 

Otherwise, the command fails with `fatal error: Unable to locate credentials`

**Note: This will still not work against staging due to permissions, but will work on the prod site.**
