### PR TITLE
Remove 'Tomogram' from Available Files filter

### DIFF
--- a/frontend/packages/data-portal/app/components/DatasetFilter/IncludedContentsFilterSection.tsx
+++ b/frontend/packages/data-portal/app/components/DatasetFilter/IncludedContentsFilterSection.tsx
@@ -26,7 +26,6 @@ const AVAILABLE_FILES_OPTIONS: AvailableFilesFilterOption[] = [
   { value: 'raw-frames', label: i18n.rawFrames },
   { value: 'tilt-series', label: i18n.tiltSeries },
   { value: 'tilt-series-alignment', label: i18n.tiltSeriesAlignment },
-  { value: 'tomogram', label: i18n.tomogram },
 ]
 
 const AVAILABLE_FILES_CLASS_NAME = 'select-available-files'


### PR DESCRIPTION
Removing `Tomogram` from the Available Files filters (as at least a stopgap) due to the query timing out.