### PR TITLE
forward visitor info for plausible

### DIFF
--- a/frontend/packages/data-portal/app/routes/api.event.ts
+++ b/frontend/packages/data-portal/app/routes/api.event.ts
@@ -1,14 +1,28 @@
 import { ActionFunctionArgs } from '@remix-run/server-runtime'
 
-export async function action({ request }: ActionFunctionArgs) {
-  const response = await fetch('https://plausible.io/api/event', {
+import { ServerContext } from 'app/types/context'
+import { removeNullishValues } from 'app/utils/object'
+
+export async function action({ request, context }: ActionFunctionArgs) {
+  const { clientIp } = context as ServerContext
+
+  const payload = {
     body: request.body,
     method: request.method,
-    headers: {
+    headers: removeNullishValues({
       'Content-Type': 'application/json',
-    },
+      'user-agent': request.headers.get('user-agent'),
+      'X-Forwarded-For': clientIp,
+    }) as HeadersInit,
+  }
+
+  // eslint-disable-next-line no-console
+  console.log({
+    message: 'Sending plausible event',
+    payload,
   })
 
+  const response = await fetch('https://plausible.io/api/event', payload)
   const responseBody = await response.text()
   const { status, headers } = response
 

--- a/frontend/packages/data-portal/app/types/context.ts
+++ b/frontend/packages/data-portal/app/types/context.ts
@@ -1,0 +1,5 @@
+import { AppLoadContext } from '@remix-run/server-runtime'
+
+export interface ServerContext extends AppLoadContext {
+  clientIp: string
+}


### PR DESCRIPTION
Fixes issue with unique visitors not being counted by forwarded the client's IP address and user agent in the plausible request to `/api/event`

Tested on https://dev-plausible-test.cryoet.dev.si.czi.technology/ and opened the website on 3 different devices (laptop, home computer, and phone on LTE)

<img width="720" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/91cce66f-5aaa-46c2-8623-ef9cb35b5627">
