### PR TITLE
Fix clipped content on left side of screen with wide window

### DIFF
--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -78,9 +78,7 @@ export function TablePageLayout({
                 'flex flex-col flex-auto w-full',
 
                 // Translate to the left by half the filter panel width to align with the header
-                'screen-2040:translate-x-[-100px]',
-
-                filterPanel && 'max-w-content',
+                filterPanel && 'screen-2040:translate-x-[-100px] max-w-content',
               )}
             >
               <div className="px-sds-xl">


### PR DESCRIPTION
This fixes #284 by only left-shifting the content when the filter panel is present.

I came here to report, only to find @andy-sweet had already reported it!

Great job on the launch! Hopefully this is the correct fix and not a distraction.