### PR TITLE
disable plausible proxying

### DIFF
--- a/frontend/packages/data-portal/app/hooks/usePlausible.ts
+++ b/frontend/packages/data-portal/app/hooks/usePlausible.ts
@@ -5,6 +5,14 @@ import { useEnvironment } from 'app/context/Environment.context'
 import { DrawerId } from 'app/state/drawer'
 import { DownloadConfig, DownloadStep, DownloadTab } from 'app/types/download'
 
+const PLAUSIBLE_EXTENSIONS = [
+  'outbound-links',
+  'file-downloads',
+  ...(process.env.LOCALHOST_PLAUSIBLE_TRACKING === 'true' ? ['local'] : []),
+].join('.')
+
+export const PLAUSIBLE_URL = `https://plausible.io/js/script.${PLAUSIBLE_EXTENSIONS}.js`
+
 export const PLAUSIBLE_ENV_URL_MAP: Record<NodeJS.ProcessEnv['ENV'], string> = {
   local: 'frontend.cryoet.dev.si.czi.technology',
   dev: 'frontend.cryoet.dev.si.czi.technology',

--- a/frontend/packages/data-portal/app/root.tsx
+++ b/frontend/packages/data-portal/app/root.tsx
@@ -23,7 +23,7 @@ import {
   ENVIRONMENT_CONTEXT_DEFAULT_VALUE,
   EnvironmentContext,
 } from './context/Environment.context'
-import { PLAUSIBLE_ENV_URL_MAP } from './hooks/usePlausible'
+import { PLAUSIBLE_ENV_URL_MAP, PLAUSIBLE_URL } from './hooks/usePlausible'
 import { i18next } from './i18next.server'
 import { useCloseDrawerOnUnmount } from './state/drawer'
 import tailwindStyles from './tailwind.css'
@@ -120,7 +120,9 @@ const Document = withEmotionCache(
           <script
             defer
             data-domain={PLAUSIBLE_ENV_URL_MAP[ENV.ENV]}
-            src="/plausible.js"
+            // TODO Fix proxying
+            // src="/plausible.js"
+            src={PLAUSIBLE_URL}
           />
 
           <meta

--- a/frontend/packages/data-portal/app/routes/plausible[.js].ts
+++ b/frontend/packages/data-portal/app/routes/plausible[.js].ts
@@ -1,14 +1,9 @@
 import { pick } from 'lodash-es'
 
-export async function loader() {
-  const extensions = [
-    'outbound-links',
-    'file-downloads',
-    ...(process.env.LOCALHOST_PLAUSIBLE_TRACKING === 'true' ? ['local'] : []),
-  ].join('.')
-  const plausibleUrl = `https://plausible.io/js/script.${extensions}.js`
+import { PLAUSIBLE_URL } from 'app/hooks/usePlausible'
 
-  const response = await fetch(plausibleUrl)
+export async function loader() {
+  const response = await fetch(PLAUSIBLE_URL)
   const script = await response.text()
   const { status, headers } = response
 


### PR DESCRIPTION
#293

Disables proxy for plausible so we get correct forwarding of user information such as the user agent and IP of the device. The disadvantage of not having the proxy is we might not be able to detect every page view, so we should eventually look into fixing the proxy completely in #296