### PR TITLE
fix firefox run table width

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -134,7 +134,7 @@ export function RunHeader() {
             )}
           </div>
 
-          <div className="flex flex-col gap-sds-xl">
+          <div className="flex flex-col gap-sds-xl flex-auto">
             <div className="flex gap-sds-xxl flex-col lg:flex-row">
               <MetadataTable
                 title={i18n.tiltSeries}


### PR DESCRIPTION
#299

Fixes the issue with firefox not showing the header metadata tables in full width

## Demo

<img width="1723" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/8609d7b6-96d5-46f6-a1cf-8404faf49b65">
