### PR TITLE
disable plausible event proxy

### DIFF
--- a/frontend/packages/data-portal/app/hooks/usePlausible.ts
+++ b/frontend/packages/data-portal/app/hooks/usePlausible.ts
@@ -72,6 +72,10 @@ export type EventPayloads = {
   }
 }
 
+// TODO Fix proxying for plausible
+// const PLAUSIBLE_EVENT_API = '/api/event'
+const PLAUSIBLE_EVENT_API = 'https://plausible.io/api/event'
+
 export function usePlausible() {
   const { ENV, LOCALHOST_PLAUSIBLE_TRACKING } = useEnvironment()
 
@@ -101,7 +105,7 @@ export function usePlausible() {
       }
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      axios.post('/api/event', payload, {
+      axios.post(PLAUSIBLE_EVENT_API, payload, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/frontend/packages/data-portal/app/root.tsx
+++ b/frontend/packages/data-portal/app/root.tsx
@@ -120,7 +120,7 @@ const Document = withEmotionCache(
           <script
             defer
             data-domain={PLAUSIBLE_ENV_URL_MAP[ENV.ENV]}
-            // TODO Fix proxying
+            // TODO Fix proxying for plausible
             // src="/plausible.js"
             src={getPlausibleUrl({
               hasLocalhostTracking: ENV.LOCALHOST_PLAUSIBLE_TRACKING === 'true',


### PR DESCRIPTION
Disables plausible proxy when sending data to the event API that was missed in #295 