### PR TITLE
reset page to 1 if page exceeds pages in filtered results

### DIFF
--- a/frontend/packages/data-portal/app/components/DatasetFilter/AnnotationMetadataFilterSection.tsx
+++ b/frontend/packages/data-portal/app/components/DatasetFilter/AnnotationMetadataFilterSection.tsx
@@ -49,6 +49,7 @@ export function AnnotationMetadataFilterSection() {
             options?.forEach((option) =>
               prev.append(QueryParams.ObjectName, option.value),
             )
+            prev.delete('page')
 
             return prev
           })

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -33,10 +33,13 @@ export function TablePageLayout({
   const page = +(searchParams.get('page') ?? '1')
 
   if (Math.ceil(filteredCount / MAX_PER_PAGE) < page) {
-    setSearchParams((prev) => {
-      prev.delete('page')
-      return prev
-    })
+    setSearchParams(
+      (prev) => {
+        prev.delete('page')
+        return prev
+      },
+      { replace: true },
+    )
   }
 
   function setPage(nextPage: number) {

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -32,6 +32,13 @@ export function TablePageLayout({
   const [searchParams, setSearchParams] = useSearchParams()
   const page = +(searchParams.get('page') ?? '1')
 
+  if (Math.ceil(filteredCount / MAX_PER_PAGE) < page) {
+    setSearchParams((prev) => {
+      prev.delete('page')
+      return prev
+    })
+  }
+
   function setPage(nextPage: number) {
     setSearchParams((prev) => {
       prev.set('page', `${nextPage}`)

--- a/frontend/packages/data-portal/app/hooks/useDatasetFilter.ts
+++ b/frontend/packages/data-portal/app/hooks/useDatasetFilter.ts
@@ -82,6 +82,7 @@ export function useDatasetFilter() {
       reset() {
         setSearchParams((prev) => {
           Object.values(QueryParams).forEach((param) => prev.delete(param))
+          prev.delete('page')
 
           return prev
         })
@@ -110,6 +111,7 @@ export function useDatasetFilter() {
 
         setSearchParams((prev) => {
           prev.delete(param)
+          prev.delete('page')
 
           if (!value) {
             return prev


### PR DESCRIPTION
fixes side-effect of #303 in which if a page was selected that was invalid due to exceeding the items in the filter, no results are displayed

preview at https://dev-kira-pagination.cryoet.dev.si.czi.technology/browse-data/datasets

https://github.com/chanzuckerberg/cryoet-data-portal/assets/29165011/78494a84-92fa-40b9-8a0d-9f695594934c

