### PR TITLE
Removing ordering author by name

### DIFF
--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -39,13 +39,9 @@ const GET_DATASETS_DATA_QUERY = gql(`
       dataset_publications
       key_photo_thumbnail_url
       related_database_entries
-
-      # TODO Remove distinct_on when data is verified to be unique
       authors(
-        distinct_on: name,
         order_by: {
           author_list_order: asc,
-          name: asc,
         },
       ) {
         name

--- a/frontend/packages/data-portal/app/routes/datasets.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/datasets.$id.tsx
@@ -52,13 +52,9 @@ const GET_DATASET_BY_ID = gql(`
       sample_preparation
       sample_type
       tissue_name
-
-      # TODO Remove distinct_on when data is verified to be unique
       authors(
-        distinct_on: name,
         order_by: {
           author_list_order: asc,
-          name: asc,
         },
       ) {
         name

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -78,12 +78,9 @@ const GET_RUN_BY_ID_QUERY = gql(`
         tissue_name
         title
 
-        # TODO Remove distinct_on when data is verified to be unique
         authors(
-          distinct_on: name,
           order_by: {
             author_list_order: asc,
-            name: asc,
           },
         ) {
           name


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/310

### Description

Removing the `distinct_on` constraint on the name, as it sorts by name first and then the other sorting fields. This results in the `author_list_order` sorting being ignored. 

