### PR TITLE
Removing stack name as tag

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           stack-name: ${{ env.STACK_NAME }}
           create-tag: true
-          tag: ${{ env.STACK_NAME }}
           tfe-token: ${{ secrets.TFE_TOKEN }}
           working-directory: ./frontend
           env: dev


### PR DESCRIPTION
Closes https://github.com/chanzuckerberg/cryoet-data-portal/issues/325

### Description

The cluster uses an image if it already exists in the machine. Using the stack name as the tag causes it to use the old image even if a new image is available, as there is no difference in their tags. Removing the explicit static tag makes happy default to the github sha as a tag. This will fix the caching issue. 


