### PR TITLE
add more error boundaries to browse datasets page

### DIFF
--- a/frontend/packages/data-portal/app/components/BrowseData/DatasetTable.tsx
+++ b/frontend/packages/data-portal/app/components/BrowseData/DatasetTable.tsx
@@ -17,6 +17,9 @@ import { ANNOTATED_OBJECTS_MAX, MAX_PER_PAGE } from 'app/constants/pagination'
 import { Dataset, useDatasets } from 'app/hooks/useDatasets'
 import { useI18n } from 'app/hooks/useI18n'
 import { useIsLoading } from 'app/hooks/useIsLoading'
+import { LogLevel } from 'app/types/logging'
+import { sendLogs } from 'app/utils/logging'
+import { getErrorMessage } from 'app/utils/string'
 
 /**
  * Max number of authors to show for dataset.
@@ -50,216 +53,224 @@ export function DatasetTable() {
   const columns = useMemo(() => {
     const columnHelper = createColumnHelper<Dataset>()
 
-    return [
-      columnHelper.accessor('id', {
-        header: () => (
-          <CellHeader
-            active={datasetSort !== undefined}
-            direction={datasetSort}
-            onClick={(event) => {
-              event.stopPropagation()
-              event.preventDefault()
-              const nextParams = new URLSearchParams(searchParams)
-
-              if (datasetSort === undefined) {
-                nextParams.set('sort', 'asc')
-              } else if (datasetSort === 'asc') {
-                nextParams.set('sort', 'desc')
-              } else {
-                nextParams.delete('sort')
-              }
-
-              setSearchParams(nextParams)
-            }}
-            errorLogId="dataset-table-title-and-photo-header"
-          >
-            {t('dataset')}
-          </CellHeader>
-        ),
-        cell({ row: { original: dataset } }) {
-          const previousUrl = `${location.pathname}${location.search}`
-          const datasetUrl = `/datasets/${dataset.id}?prev=${encodeURIComponent(
-            previousUrl,
-          )}`
-
-          return (
-            <TableCell
-              className="flex px-sds-s py-sds-l gap-sds-m"
-              renderLoadingSkeleton={false}
-              minWidth={450}
-              maxWidth={800}
-              errorLogId="dataset-table-title-and-photo"
-            >
-              <Link to={datasetUrl} className="flex-shrink-0 w-[134px]">
-                <KeyPhoto
-                  title={dataset.title}
-                  src={dataset.key_photo_thumbnail_url ?? undefined}
-                  loading={isLoadingDebounced}
-                />
-              </Link>
-
-              <div className="flex flex-col flex-auto gap-sds-xxxs min-h-[100px]">
-                <p className="text-sm font-semibold text-sds-primary-400">
-                  {isLoadingDebounced ? (
-                    <Skeleton className="max-w-[70%]" variant="text" />
-                  ) : (
-                    <Link to={datasetUrl}>{dataset.title}</Link>
-                  )}
-                </p>
-
-                <p className="text-xs text-sds-gray-600">
-                  {isLoadingDebounced ? (
-                    <Skeleton className="max-w-[120px]" variant="text" />
-                  ) : (
-                    `${t('portalId')}: ${dataset.id}`
-                  )}
-                </p>
-
-                <p className="text-xs text-sds-gray-500 mt-sds-s">
-                  {isLoadingDebounced ? (
-                    <>
-                      <Skeleton className="max-w-[80%] mt-2" variant="text" />
-
-                      <Skeleton className=" max-w-[50%] mt-2" variant="text" />
-                    </>
-                  ) : (
-                    <>
-                      {dataset.authors
-                        .slice(
-                          0,
-                          dataset.authors.length > AUTHOR_MAX
-                            ? AUTHOR_MAX - 1
-                            : Infinity,
-                        )
-                        .map((author, idx) => (
-                          <span key={author.name}>
-                            {author.name}
-                            {idx < dataset.authors.length - 1 && '; '}
-                          </span>
-                        ))}
-
-                      {dataset.authors.length > AUTHOR_MAX && (
-                        <Link
-                          className="text-sds-primary-500 inline"
-                          to={datasetUrl}
-                        >
-                          + {dataset.authors.length + 1 - AUTHOR_MAX} more
-                        </Link>
-                      )}
-                    </>
-                  )}
-                </p>
-              </div>
-            </TableCell>
-          )
-        },
-      }),
-
-      columnHelper.accessor('related_database_entries', {
-        header: t('empiarID'),
-        cell({ getValue }) {
-          const empiarIDMatch = EMPIAR_ID.exec(getValue() ?? '')
-          const empiarID = empiarIDMatch?.[1]
-
-          return (
-            <TableCell
-              minWidth={120}
-              maxWidth={130}
-              errorLogId="dataset-table-empiar-id"
-            >
-              {empiarID ? (
-                <Link
-                  className="text-sds-primary-500 inline"
-                  to={`${EMPIAR_URL}${empiarID}`}
-                >
-                  EMPIAR-{empiarID}
-                </Link>
-              ) : (
-                <p>--</p>
-              )}
-            </TableCell>
-          )
-        },
-      }),
-
-      columnHelper.accessor('organism_name', {
-        header: t('organismName'),
-        cell: ({ getValue }) => (
-          <TableCell
-            primaryText={getValue() ?? '--'}
-            minWidth={100}
-            maxWidth={400}
-            errorLogId="dataset-table-organism-name"
-          />
-        ),
-      }),
-
-      columnHelper.accessor(
-        (dataset) => dataset.runs_aggregate.aggregate?.count,
-        {
-          id: 'runs',
+    try {
+      return [
+        columnHelper.accessor('id', {
           header: () => (
             <CellHeader
-              hideSortIcon
-              tooltip={<I18n i18nKey="runsTooltip" />}
-              arrowPadding={{ right: 270 }}
-              errorLogId="dataset-table-runs-header"
+              active={datasetSort !== undefined}
+              direction={datasetSort}
+              onClick={(event) => {
+                event.stopPropagation()
+                event.preventDefault()
+                const nextParams = new URLSearchParams(searchParams)
+
+                if (datasetSort === undefined) {
+                  nextParams.set('sort', 'asc')
+                } else if (datasetSort === 'asc') {
+                  nextParams.set('sort', 'desc')
+                } else {
+                  nextParams.delete('sort')
+                }
+
+                setSearchParams(nextParams)
+              }}
             >
-              {t('runs')}
+              {t('dataset')}
             </CellHeader>
           ),
+          cell({ row: { original: dataset } }) {
+            const previousUrl = `${location.pathname}${location.search}`
+            const datasetUrl = `/datasets/${
+              dataset.id
+            }?prev=${encodeURIComponent(previousUrl)}`
+
+            return (
+              <TableCell
+                className="flex px-sds-s py-sds-l gap-sds-m"
+                renderLoadingSkeleton={false}
+                minWidth={450}
+                maxWidth={800}
+              >
+                <Link to={datasetUrl} className="flex-shrink-0 w-[134px]">
+                  <KeyPhoto
+                    title={dataset.title}
+                    src={dataset.key_photo_thumbnail_url ?? undefined}
+                    loading={isLoadingDebounced}
+                  />
+                </Link>
+
+                <div className="flex flex-col flex-auto gap-sds-xxxs min-h-[100px]">
+                  <p className="text-sm font-semibold text-sds-primary-400">
+                    {isLoadingDebounced ? (
+                      <Skeleton className="max-w-[70%]" variant="text" />
+                    ) : (
+                      <Link to={datasetUrl}>{dataset.title}</Link>
+                    )}
+                  </p>
+
+                  <p className="text-xs text-sds-gray-600">
+                    {isLoadingDebounced ? (
+                      <Skeleton className="max-w-[120px]" variant="text" />
+                    ) : (
+                      `${t('portalId')}: ${dataset.id}`
+                    )}
+                  </p>
+
+                  <p className="text-xs text-sds-gray-500 mt-sds-s">
+                    {isLoadingDebounced ? (
+                      <>
+                        <Skeleton className="max-w-[80%] mt-2" variant="text" />
+
+                        <Skeleton
+                          className=" max-w-[50%] mt-2"
+                          variant="text"
+                        />
+                      </>
+                    ) : (
+                      <>
+                        {dataset.authors
+                          .slice(
+                            0,
+                            dataset.authors.length > AUTHOR_MAX
+                              ? AUTHOR_MAX - 1
+                              : Infinity,
+                          )
+                          .map((author, idx) => (
+                            <span key={author.name}>
+                              {author.name}
+                              {idx < dataset.authors.length - 1 && '; '}
+                            </span>
+                          ))}
+
+                        {dataset.authors.length > AUTHOR_MAX && (
+                          <Link
+                            className="text-sds-primary-500 inline"
+                            to={datasetUrl}
+                          >
+                            + {dataset.authors.length + 1 - AUTHOR_MAX} more
+                          </Link>
+                        )}
+                      </>
+                    )}
+                  </p>
+                </div>
+              </TableCell>
+            )
+          },
+        }),
+
+        columnHelper.accessor('related_database_entries', {
+          header: t('empiarID'),
+          cell({ getValue }) {
+            const empiarIDMatch = EMPIAR_ID.exec(getValue() ?? '')
+            const empiarID = empiarIDMatch?.[1]
+
+            return (
+              <TableCell minWidth={120} maxWidth={130}>
+                {empiarID ? (
+                  <Link
+                    className="text-sds-primary-500 inline"
+                    to={`${EMPIAR_URL}${empiarID}`}
+                  >
+                    EMPIAR-{empiarID}
+                  </Link>
+                ) : (
+                  <p>--</p>
+                )}
+              </TableCell>
+            )
+          },
+        }),
+
+        columnHelper.accessor('organism_name', {
+          header: t('organismName'),
           cell: ({ getValue }) => (
             <TableCell
-              primaryText={String(getValue() ?? 0)}
-              minWidth={70}
-              maxWidth={100}
-              errorLogId="dataset-table-runs"
+              primaryText={getValue() ?? '--'}
+              minWidth={100}
+              maxWidth={400}
             />
           ),
-        },
-      ),
+        }),
 
-      columnHelper.accessor((dataset) => dataset.runs, {
-        // TODO: fix overflow for this header
-        header: t('annotatedObjects'),
-        cell({ getValue }) {
-          const runs = getValue()
-          const annotatedObjects = Array.from(
-            new Set(
-              runs.flatMap((run) =>
-                run.tomogram_voxel_spacings.flatMap((voxelSpacing) =>
-                  voxelSpacing.annotations.flatMap(
-                    (annotation) => annotation.object_name,
+        columnHelper.accessor(
+          (dataset) => dataset.runs_aggregate.aggregate?.count,
+          {
+            id: 'runs',
+            header: () => (
+              <CellHeader
+                hideSortIcon
+                tooltip={<I18n i18nKey="runsTooltip" />}
+                arrowPadding={{ right: 270 }}
+              >
+                {t('runs')}
+              </CellHeader>
+            ),
+            cell: ({ getValue }) => (
+              <TableCell
+                primaryText={String(getValue() ?? 0)}
+                minWidth={70}
+                maxWidth={100}
+              />
+            ),
+          },
+        ),
+
+        columnHelper.accessor((dataset) => dataset.runs, {
+          // TODO: fix overflow for this header
+          header: t('annotatedObjects'),
+          cell({ getValue }) {
+            const runs = getValue()
+            const annotatedObjects = Array.from(
+              new Set(
+                runs.flatMap((run) =>
+                  run.tomogram_voxel_spacings.flatMap((voxelSpacing) =>
+                    voxelSpacing.annotations.flatMap(
+                      (annotation) => annotation.object_name,
+                    ),
                   ),
                 ),
               ),
-            ),
-          )
+            )
 
-          return (
-            <TableCell
-              minWidth={120}
-              maxWidth={400}
-              className="w-[15%]"
-              renderLoadingSkeleton={() => (
-                <div className="flex flex-col gap-2">
-                  {range(0, ANNOTATED_OBJECTS_MAX).map((val) => (
-                    <Skeleton key={`skeleton-${val}`} variant="rounded" />
-                  ))}
-                </div>
-              )}
-              errorLogId="dataset-table-annotated-objects"
-            >
-              {annotatedObjects.length === 0 ? (
-                '--'
-              ) : (
-                <AnnotatedObjectsList annotatedObjects={annotatedObjects} />
-              )}
-            </TableCell>
-          )
-        },
-      }),
-    ] as ColumnDef<Dataset>[]
+            return (
+              <TableCell
+                minWidth={120}
+                maxWidth={400}
+                className="w-[15%]"
+                renderLoadingSkeleton={() => (
+                  <div className="flex flex-col gap-2">
+                    {range(0, ANNOTATED_OBJECTS_MAX).map((val) => (
+                      <Skeleton key={`skeleton-${val}`} variant="rounded" />
+                    ))}
+                  </div>
+                )}
+              >
+                {annotatedObjects.length === 0 ? (
+                  '--'
+                ) : (
+                  <AnnotatedObjectsList annotatedObjects={annotatedObjects} />
+                )}
+              </TableCell>
+            )
+          },
+        }),
+      ] as ColumnDef<Dataset>[]
+    } catch (err) {
+      sendLogs({
+        level: LogLevel.Error,
+        messages: [
+          {
+            type: 'browser',
+            message: 'Error creating columns for dataset table',
+            error: getErrorMessage(err),
+          },
+        ],
+      })
+
+      throw err
+    }
   }, [
     datasetSort,
     isLoadingDebounced,

--- a/frontend/packages/data-portal/app/components/Table/CellHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Table/CellHeader.tsx
@@ -10,11 +10,8 @@ import {
   TooltipOffset,
 } from 'app/components/Tooltip'
 
-import { ErrorBoundary } from '../ErrorBoundary'
-
 export function CellHeader({
   arrowPadding,
-  errorLogId,
   offset,
   tooltip,
   ...props
@@ -23,21 +20,18 @@ export function CellHeader({
   'shouldShowTooltipOnHover' | 'tooltipText' | 'tooltipSubtitle'
 > & {
   arrowPadding?: TooltipArrowPadding
-  errorLogId?: string
   offset?: TooltipOffset
   tooltip?: ReactNode
 }) {
   return (
-    <ErrorBoundary logId={errorLogId}>
-      <SDSCellHeader
-        {...props}
-        shouldShowTooltipOnHover={!!tooltip}
-        tooltipProps={getTooltipProps({ arrowPadding, offset })}
-        // TODO Remove ts-ignore when types is updated to use ReactNode
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        tooltipText={tooltip}
-      />
-    </ErrorBoundary>
+    <SDSCellHeader
+      {...props}
+      shouldShowTooltipOnHover={!!tooltip}
+      tooltipProps={getTooltipProps({ arrowPadding, offset })}
+      // TODO Remove ts-ignore when types is updated to use ReactNode
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      tooltipText={tooltip}
+    />
   )
 }

--- a/frontend/packages/data-portal/app/components/Table/Table.tsx
+++ b/frontend/packages/data-portal/app/components/Table/Table.tsx
@@ -12,8 +12,8 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { Fragment } from 'react'
 
+import { ErrorBoundary } from 'app/components/ErrorBoundary'
 import { useLayout } from 'app/context/Layout.context'
 import { cns } from 'app/utils/cns'
 
@@ -42,6 +42,10 @@ export function Table<T>({
     getCoreRowModel: getCoreRowModel(),
   })
 
+  function getLogId(id: string) {
+    return `${tableProps?.id ? `${tableProps.id}-` : ''}table-${id}`
+  }
+
   return (
     <TableContainer
       className={cns(
@@ -61,13 +65,16 @@ export function Table<T>({
             )
 
             return (
-              <Fragment key={header.id}>
+              <ErrorBoundary
+                key={header.id}
+                logId={getLogId(`header-${header.id}`)}
+              >
                 {typeof content !== 'string' ? (
                   content
                 ) : (
                   <CellHeader hideSortIcon>{content}</CellHeader>
                 )}
-              </Fragment>
+              </ErrorBoundary>
             )
           })}
         </TableHeader>
@@ -76,9 +83,12 @@ export function Table<T>({
           {table.getRowModel().rows.map((row) => (
             <TableRow key={row.id}>
               {row.getVisibleCells().map((cell) => (
-                <Fragment key={cell.id}>
+                <ErrorBoundary
+                  key={cell.id}
+                  logId={getLogId(`cell-${cell.id}`)}
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Fragment>
+                </ErrorBoundary>
               ))}
             </TableRow>
           ))}

--- a/frontend/packages/data-portal/app/components/Table/TableCell.tsx
+++ b/frontend/packages/data-portal/app/components/Table/TableCell.tsx
@@ -3,7 +3,6 @@ import Skeleton from '@mui/material/Skeleton'
 import { ReactNode } from 'react'
 import { match } from 'ts-pattern'
 
-import { ErrorBoundary } from 'app/components/ErrorBoundary'
 import { getTooltipProps, Tooltip, TooltipProps } from 'app/components/Tooltip'
 import { useIsLoading } from 'app/hooks/useIsLoading'
 import { cns } from 'app/utils/cns'
@@ -11,7 +10,6 @@ import { cns } from 'app/utils/cns'
 export function TableCell({
   children,
   className,
-  errorLogId,
   horizontalAlign,
   maxWidth,
   minWidth,
@@ -22,7 +20,6 @@ export function TableCell({
 }: {
   children?: ReactNode
   className?: string
-  errorLogId?: string
   horizontalAlign?: 'left' | 'center' | 'right'
   loadingSkeleton?: boolean
   maxWidth?: number
@@ -81,9 +78,5 @@ export function TableCell({
     )
   }
 
-  return (
-    <ErrorBoundary logId={errorLogId}>
-      <CellComponent {...cellProps}>{content}</CellComponent>
-    </ErrorBoundary>
-  )
+  return <CellComponent {...cellProps}>{content}</CellComponent>
 }

--- a/frontend/packages/data-portal/app/utils/logging.ts
+++ b/frontend/packages/data-portal/app/utils/logging.ts
@@ -5,7 +5,7 @@ import { LogApiRequestBody, LogApiResponse, LogEntry } from 'app/types/logging'
 let LOG_QUEUE: LogEntry[] = []
 let logQueueTimeoutId: number | null = null
 
-export function sendLogs(logs: LogEntry[]) {
+export function sendLogs(...logs: LogEntry[]) {
   LOG_QUEUE.push(...logs)
 
   if (!logQueueTimeoutId) {

--- a/frontend/packages/data-portal/app/utils/string.ts
+++ b/frontend/packages/data-portal/app/utils/string.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+export function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.message
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}


### PR DESCRIPTION
#215

- Adds `getErrorMessage()` util function
- Updates `sendLogs()` to accept `...logs: LogEntry[]` instead of `logs: LogEntry[]`
- Moves table error boundaries to `Table` component
- Add `sendLogs()` for column creation 