### PR TITLE
fix: Mapping samplings available to db field

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -164,7 +164,9 @@ export function RunHeader() {
                     inline: true,
                     values: run.tomogram_stats
                       .flatMap((stats) => stats.tomogram_resolutions)
-                      .map((resolutions) => resolutions.voxel_spacing),
+                      .map((resolutions) =>
+                        t('unitAngstrom', { value: resolutions.voxel_spacing }),
+                      ),
                   },
                   {
                     label: i18n.tomogramProcessing,

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -161,6 +161,7 @@ export function RunHeader() {
                 data={[
                   {
                     label: i18n.resolutionsAvailable,
+                    inline: true,
                     values: run.tomogram_stats
                       .flatMap((stats) => stats.tomogram_resolutions)
                       .map((resolutions) => resolutions.voxel_spacing),

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -161,7 +161,9 @@ export function RunHeader() {
                 data={[
                   {
                     label: i18n.resolutionsAvailable,
-                    values: ['10.00Å, 13.70Å'],
+                    values: run.tomogram_stats
+                      .flatMap((stats) => stats.tomogram_resolutions)
+                      .map((resolutions) => resolutions.voxel_spacing),
                   },
                   {
                     label: i18n.tomogramProcessing,


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/394

Updates `sampling available` value to be updated from existing field in the query [here](https://github.com/chanzuckerberg/cryoet-data-portal/blob/498e4e02af55e01e9a3d70eca625931d19977eee/frontend/packages/data-portal/app/graphql/getRunById.server.ts#L182).


Demo:

![Screenshot 2024-02-20 at 6 22 54 PM](https://github.com/chanzuckerberg/cryoet-data-portal/assets/14958785/5905a62a-9a70-46ba-98c8-a8c84a010b72)


