### PR TITLE
fix: remove axios cache

### DIFF
--- a/frontend/packages/data-portal/app/axios.ts
+++ b/frontend/packages/data-portal/app/axios.ts
@@ -1,5 +1,0 @@
-import Axios from 'axios'
-import { setupCache } from 'axios-cache-interceptor'
-
-export const axios =
-  process.env.NODE_ENV === 'production' ? setupCache(Axios) : Axios

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -2,11 +2,10 @@
 
 import { ShouldRevalidateFunctionArgs } from '@remix-run/react'
 import { json, LoaderFunctionArgs } from '@remix-run/server-runtime'
-import { AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import { isNumber, sum } from 'lodash-es'
 
 import { apolloClient } from 'app/apollo.server'
-import { axios } from 'app/axios'
 import { DownloadModal } from 'app/components/Download'
 import { RunHeader } from 'app/components/Run'
 import { AnnotationDrawer } from 'app/components/Run/AnnotationDrawer'

--- a/frontend/packages/data-portal/app/utils/repo.server.ts
+++ b/frontend/packages/data-portal/app/utils/repo.server.ts
@@ -1,5 +1,5 @@
 import rehypePrism from '@mapbox/rehype-prism'
-import { AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import { readFileSync } from 'fs'
 import { serialize } from 'next-mdx-remote/serialize'
 import { Octokit } from 'octokit'
@@ -8,8 +8,6 @@ import remarkGfm from 'remark-gfm'
 import sectionize from 'remark-sectionize'
 import { typedjson } from 'remix-typedjson'
 import { fileURLToPath } from 'url'
-
-import { axios } from 'app/axios'
 
 const octokit = new Octokit()
 


### PR DESCRIPTION
#297 

This should fix the issue we're having with CORS error with plausible. Looks like it's a result of a caching issue with the `axios-cache-interceptor` module.

We didn't really use this module that much since we use GraphQL for data fetching, so we can remove it 