### PR TITLE
fix: fix deploy var

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -16,8 +16,8 @@ jobs:
     name: Run e2e test on staging
     uses: chanzuckerberg/cryoet-data-portal/.github/workflows/frontend-e2e-tests.yml@main
     secrets: inherit
-    # The secret IS_DEPLOY_ALLOWED is used to manually gate the prod deploys
-    if: ${{ secrets.IS_DEPLOY_ALLOWED == 'true' }}
+    # The variable IS_DEPLOY_ALLOWED is used to manually gate the prod deploys
+    if: vars.IS_DEPLOY_ALLOWED == 'true'
     with:
       environment: staging
 


### PR DESCRIPTION
Fixes issue with prod deploy due to secrets not being available for job conditionals: https://github.com/actions/runner/issues/520

This switches to using a repository variable which should be appropriate since the value can only be `true` or `false`