### PR TITLE
chore: support more conventional commit types

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,4 +16,6 @@ jobs:
   conventional_commit_title:
     runs-on: [ARM64, self-hosted, Linux]
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v2.1.0
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/amannn/action-semantic-pull-request for the conventional commit title check to support more conventional commit types in the PR title