### PR TITLE
chore: update tilt range label

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -15,6 +15,7 @@ import {
 } from 'app/hooks/useMetadataDrawer'
 import { useRunById } from 'app/hooks/useRunById'
 import { i18n } from 'app/i18n'
+import { getTiltRangeLabel } from 'app/utils/tiltSeries'
 
 import { ViewTomogramButton } from '../ViewTomogramButton'
 
@@ -134,14 +135,15 @@ export function RunHeader() {
                     ),
                   },
                   {
-                    label: i18n.tiltRange,
+                    label: t('tiltRange'),
                     values:
                       typeof tiltSeries?.tilt_min === 'number' &&
                       typeof tiltSeries?.tilt_max === 'number'
                         ? [
-                            i18n.valueToValue(
-                              i18n.unitDegree(tiltSeries.tilt_min),
-                              i18n.unitDegree(tiltSeries.tilt_max),
+                            getTiltRangeLabel(
+                              t,
+                              tiltSeries.tilt_min,
+                              tiltSeries.tilt_max,
                             ),
                           ]
                         : [],

--- a/frontend/packages/data-portal/app/components/TiltSeriesTable/useTiltSeriesValueMappings.tsx
+++ b/frontend/packages/data-portal/app/components/TiltSeriesTable/useTiltSeriesValueMappings.tsx
@@ -5,6 +5,7 @@ import { Tiltseries } from 'app/__generated__/graphql'
 import { DatabaseEntry } from 'app/components/DatabaseEntry'
 import { useI18n } from 'app/hooks/useI18n'
 import { TableData } from 'app/types/table'
+import { getTiltRangeLabel } from 'app/utils/tiltSeries'
 
 import { TiltSeriesKeys } from './constants'
 
@@ -134,10 +135,7 @@ export function useTiltSeriesValueMappings(tiltSeries?: Partial<Tiltseries>) {
           tiltSeries &&
           isNumber(tiltSeries?.tilt_min) &&
           isNumber(tiltSeries.tilt_max)
-            ? t('valueToValue', {
-                value1: t('unitDegree', { value: tiltSeries.tilt_min }),
-                value2: t('unitDegree', { value: tiltSeries.tilt_max }),
-              })
+            ? getTiltRangeLabel(t, tiltSeries.tilt_min, tiltSeries.tilt_max)
             : '--',
         ],
       },

--- a/frontend/packages/data-portal/app/hooks/useI18n.ts
+++ b/frontend/packages/data-portal/app/hooks/useI18n.ts
@@ -7,3 +7,5 @@ import { useTranslation, UseTranslationOptions } from 'react-i18next'
 export function useI18n(options?: UseTranslationOptions<undefined>) {
   return useTranslation('translation', options)
 }
+
+export type I18nTFunction = ReturnType<typeof useI18n>['t']

--- a/frontend/packages/data-portal/app/hooks/useTiltRangeLabel.ts
+++ b/frontend/packages/data-portal/app/hooks/useTiltRangeLabel.ts
@@ -1,0 +1,21 @@
+import { isNumber } from 'lodash-es'
+
+import { useI18n } from './useI18n'
+
+export function useTiltRangeLabel(
+  min: number | null | undefined,
+  max: number | null | undefined,
+) {
+  const { t } = useI18n()
+
+  if (!isNumber(min) || !isNumber(max)) {
+    return '--'
+  }
+
+  return `${t('unitDegree', {
+    value: max - min,
+  })} (${t('valueToValue', {
+    value1: t('unitDegree', { value: min }),
+    value2: t('unitDegree', { value: max }),
+  })})`
+}

--- a/frontend/packages/data-portal/app/utils/tiltSeries.ts
+++ b/frontend/packages/data-portal/app/utils/tiltSeries.ts
@@ -1,7 +1,17 @@
 import { inRange } from 'lodash-es'
 
 import { TiltSeriesScore } from 'app/constants/tiltSeries'
+import type { I18nTFunction } from 'app/hooks/useI18n'
 
 export function inQualityScoreRange(score: number): score is TiltSeriesScore {
   return inRange(score, TiltSeriesScore.VeryPoor, TiltSeriesScore.Excellent + 1)
+}
+
+export function getTiltRangeLabel(t: I18nTFunction, min: number, max: number) {
+  return `${t('unitDegree', {
+    value: max - min,
+  })} (${t('valueToValue', {
+    value1: t('unitDegree', { value: min }),
+    value2: t('unitDegree', { value: max }),
+  })})`
 }


### PR DESCRIPTION
#456

- Adds reusable util for creating tilt range label
- Updates the tilt range label for the tilt series table and run header table

## Demo

<img width="587" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/bf7b62c8-0473-4072-9b57-9a6f0a33a877">

<img width="370" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/c80e49ef-36cd-4aba-aa9b-0ea13251e70f">
