### PR TITLE
fix: no tomogram error

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/TomogramsTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/TomogramsTable.tsx
@@ -8,7 +8,11 @@ import { Matrix4x4 } from './Matrix4x4'
 export function TomogramsTable() {
   const { run } = useRunById()
 
-  const tomo = run.tomogram_voxel_spacings[0].tomograms[0]
+  const tomo = run.tomogram_voxel_spacings.at(0)?.tomograms.at(0)
+
+  if (!tomo) {
+    return null
+  }
 
   const tomogramsTableData = getTableData(
     {


### PR DESCRIPTION
#530

Fixes issue with frontend throwing an application error when opening the metadata drawer when there are no tomograms in the tilt series

## Demo

### Before

<img width="927" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/8b05c6cf-6713-4571-9843-d59cb3eea10a">

### After

Hides tomogram metadata panel when undefined 

<img width="504" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/2f38636e-28db-4b29-a01f-e8ced37acc6f">