### PR TITLE
chore: hide download annotation button behind flag

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -71,6 +71,7 @@ export function AnnotationTable() {
   )
 
   const showMethodType = useFeatureFlag('methodType')
+  const showAnnotationDownload = useFeatureFlag('downloadSingleAnnotation')
 
   const columns = useMemo(() => {
     const columnHelper = createColumnHelper<Annotation>()
@@ -288,36 +289,39 @@ export function AnnotationTable() {
                 <span>{t('moreInfo')}</span>
               </Button>
 
-              <Button
-                sdsType="primary"
-                sdsStyle="minimal"
-                onClick={() =>
-                  openAnnotationDownloadModal({
-                    datasetId: run.dataset.id,
-                    runId: run.id,
-                    annotationId: annotation.id,
-                    // FIXME: are we supposed to only access the 1st option? (this is how it is done elsewhere)
-                    objectShapeType: annotation.files[0].shape_type,
-                  })
-                }
-                startIcon={
-                  <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-                }
-              >
-                {t('download')}
-              </Button>
+              {showAnnotationDownload && (
+                <Button
+                  sdsType="primary"
+                  sdsStyle="minimal"
+                  onClick={() =>
+                    openAnnotationDownloadModal({
+                      datasetId: run.dataset.id,
+                      runId: run.id,
+                      annotationId: annotation.id,
+                      // FIXME: are we supposed to only access the 1st option? (this is how it is done elsewhere)
+                      objectShapeType: annotation.files[0].shape_type,
+                    })
+                  }
+                  startIcon={
+                    <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+                  }
+                >
+                  {t('download')}
+                </Button>
+              )}
             </div>
           </TableCell>
         ),
       }),
     ] as ColumnDef<Annotation>[]
   }, [
+    t,
+    showMethodType,
     openAnnotationDrawer,
+    showAnnotationDownload,
     openAnnotationDownloadModal,
     run.dataset.id,
     run.id,
-    showMethodType,
-    t,
   ])
 
   const annotations = useMemo<Annotation[]>(

--- a/frontend/packages/data-portal/app/utils/featureFlags.ts
+++ b/frontend/packages/data-portal/app/utils/featureFlags.ts
@@ -4,9 +4,10 @@ import { useEnvironment } from 'app/context/Environment.context'
 
 export type FeatureFlagEnvironment = typeof process.env.ENV
 
-export type FeatureFlagKey = 'methodType'
+export type FeatureFlagKey = 'downloadSingleAnnotation' | 'methodType'
 
 export const FEATURE_FLAGS: Record<FeatureFlagKey, FeatureFlagEnvironment[]> = {
+  downloadSingleAnnotation: ['local', 'dev'],
   methodType: ['local', 'dev'],
 }
 


### PR DESCRIPTION
Hides the download annotation button behind a feature flag to unblock deployment. We'll ship the feature once #589 is merged

## Before

<img width="301" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/7d2af9b8-5a20-4128-9378-2e50d081b17b">

## After

<img width="295" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/08d4e606-1e2f-48b1-a03d-5c47c64e1c6c">
