### PR TITLE
docs: Minor updates to documentation site

### DIFF
--- a/docs/cryoet_data_portal_docsite_examples.md
+++ b/docs/cryoet_data_portal_docsite_examples.md
@@ -38,7 +38,7 @@ object_datasets = set([po.tomogram_voxel_spacing.run.dataset_id for po in portal
 </details>
 
 <details>
-  <summary>List zarr file contents using the zarr-package and HTTPS link</summary>
+  <summary>List zarr file contents using the zarr package and HTTPS link</summary>
 
 Stream data using https
 
@@ -66,7 +66,7 @@ for i in g.attrs["multiscales"][0]["datasets"]:
 </details>
 
 <details>
-  <summary>List zarr-file contents using the ome-zarr-package and HTTPS link</summary>
+  <summary>List zarr-file contents using the ome-zarr package and HTTPS link</summary>
 
 Stream data using https
 
@@ -92,7 +92,7 @@ nodes[0].data
 </details>
 
 <details>
-  <summary>List zarr-file contents using the zarr-package and s3 link</summary>
+  <summary>List zarr-file contents using the zarr package and S3 link</summary>
 
 Stream data via S3
 
@@ -112,7 +112,7 @@ g.info_items()
 </details>
 
 <details>
-  <summary>Open a tomogram array the zarr-package and https link</summary>
+  <summary>Open a tomogram array using the zarr package and HTTPS link</summary>
 
 Stream data using https
 
@@ -130,7 +130,7 @@ g = zarr.open_array(f"{tomo.https_omezarr_dir}/0", mode='r')
 </details>
 
 <details>
-  <summary>Find all annotation files available in Zarr-format from a dataset</summary>
+  <summary>Find all annotation files available in ZARR format from a dataset</summary>
 
 Use as training data for a segmentation model
 

--- a/docs/cryoet_data_portal_docsite_quick_start.md
+++ b/docs/cryoet_data_portal_docsite_quick_start.md
@@ -71,7 +71,7 @@ Dataset: S. pombe cells with defocus
 
 ### Find all tomograms for a certain organism and download preview-sized MRC files:
 
-The following iterates over all tomograms related to a specific organism and downloads a 25% scale preview tomogram in MRC format for each one.
+The following iterates over all tomograms related to a specific organism and downloads each tomogram in MRC format.
 
 ```python
 import json


### PR DESCRIPTION
Apart from some small typos and such, a meaningful change is removing a mention of scaling in one of the quick start examples, since tomograms are not binned any more (noticed during a meeting with Utz).

The updated wording doesn't get into details, but I had two questions:
- Are the tomograms that will get downloaded the highest *available* resolution, but not necessarily the maximum *possible* resolution? Answer: Yes.
- When the code iterates over all tomograms, are they unique, or can there be different resolutions of the same tomogram? Answer: There can be, but there are none right now.