### PR TITLE
fix: Raise exception when attempting to filter on related objects.

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -21,7 +21,7 @@ class GQLExpression:
                 fieldname = [fieldname]
 
             raise Exception(
-                f"\"{'.'.join(fieldname)}\" is an object and can't be filtered directly. Please filter on one of its scalar attributes instead: {', '.join(scalar_fields)}"
+                f"\"{'.'.join(fieldname)}\" is an object and can't be filtered directly. Please filter on one of its scalar attributes instead: {', '.join(scalar_fields)}",
             )
         gql = {}
         if isinstance(fieldname, list):

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -14,6 +14,15 @@ class GQLExpression:
 
     def to_gql(self) -> Dict[str, Any]:
         fieldname = self.field.to_gql()
+        if self.field.is_relationship():
+            related_cls = self.field.get_related_class()
+            scalar_fields = related_cls._get_scalar_fields()
+            if isinstance(fieldname, str):
+                fieldname = [fieldname]
+
+            raise Exception(
+                f"\"{'.'.join(fieldname)}\" is an object and can't be filtered directly. Please filter on one of its scalar attributes instead: {', '.join(scalar_fields)}"
+            )
         gql = {}
         if isinstance(fieldname, list):
             for item in fieldname[::-1]:
@@ -63,6 +72,11 @@ class GQLField:
         self._cls = cls
         self._name = name
 
+    def is_relationship(self):
+        if isinstance(self, Relationship):
+            return True
+        return False
+
     def to_gql(self):
         return self._name
 
@@ -110,6 +124,14 @@ class QueryChain(GQLField):
         self.__name.append(attr)
         return self
 
+    def is_relationship(self):
+        if isinstance(self.__current_query, Relationship):
+            return True
+        return False
+
+    def get_related_class(self):
+        return self.__current_query.get_related_class()
+
     def to_gql(self):
         return self.__name
 
@@ -132,6 +154,9 @@ class Relationship(GQLField):
         # Helpers for resolving GQL field names.
         self._cls = cls
         self._name = name
+
+    def get_related_class(self):
+        return self.related_class
 
     def resolve_class(self):
         if type(self.related_class) is not type:

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -21,7 +21,7 @@ class GQLExpression:
                 fieldname = [fieldname]
 
             raise Exception(
-                f"\"{'.'.join(fieldname)}\" is an object and can't be filtered directly. Please filter on one of its scalar attributes instead: {', '.join(scalar_fields)}",
+                f"\"{'.'.join(fieldname)}\" is an object and can't be compared directly. Please filter on one of its scalar attributes instead: {', '.join(scalar_fields)}",
             )
         gql = {}
         if isinstance(fieldname, list):

--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -1,5 +1,6 @@
-from cryoet_data_portal import Run, Tomogram
 import pytest
+
+from cryoet_data_portal import Run, Tomogram
 
 
 def test_basic_filters(client) -> None:
@@ -9,7 +10,7 @@ def test_basic_filters(client) -> None:
     assert runs[0].name == "RUN1"
 
     tomograms = Tomogram.find(
-        client, [Tomogram.tomogram_voxel_spacing.run.name == "RUN1"]
+        client, [Tomogram.tomogram_voxel_spacing.run.name == "RUN1"],
     )
     assert len(tomograms) == 1
     assert tomograms[0].tomogram_voxel_spacing.run.name == "RUN1"

--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -10,7 +10,8 @@ def test_basic_filters(client) -> None:
     assert runs[0].name == "RUN1"
 
     tomograms = Tomogram.find(
-        client, [Tomogram.tomogram_voxel_spacing.run.name == "RUN1"],
+        client,
+        [Tomogram.tomogram_voxel_spacing.run.name == "RUN1"],
     )
     assert len(tomograms) == 1
     assert tomograms[0].tomogram_voxel_spacing.run.name == "RUN1"
@@ -22,11 +23,11 @@ def test_filter_on_object_raises_exceptions(client) -> None:
         Run.find(client, [Run.tomogram_voxel_spacings.annotations == 20001])
     assert (
         exc_info.value.args[0]
-        == '"tomogram_voxel_spacings.annotations" is an object and can\'t be filtered directly. Please filter on one of its scalar attributes instead: annotation_method, annotation_publication, annotation_software, confidence_precision, confidence_recall, deposition_date, ground_truth_status, ground_truth_used, https_metadata_path, id, is_curator_recommended, last_modified_date, object_count, object_description, object_id, object_name, object_state, release_date, s3_metadata_path, tomogram_voxel_spacing_id'
+        == '"tomogram_voxel_spacings.annotations" is an object and can\'t be compared directly. Please filter on one of its scalar attributes instead: annotation_method, annotation_publication, annotation_software, confidence_precision, confidence_recall, deposition_date, ground_truth_status, ground_truth_used, https_metadata_path, id, is_curator_recommended, last_modified_date, object_count, object_description, object_id, object_name, object_state, release_date, s3_metadata_path, tomogram_voxel_spacing_id'
     )
     with pytest.raises(Exception) as exc_info:
         Run.find(client, [Run.dataset == 20001])
     assert (
         exc_info.value.args[0]
-        == '"dataset" is an object and can\'t be filtered directly. Please filter on one of its scalar attributes instead: id, cell_component_id, cell_component_name, cell_name, cell_strain_id, cell_strain_name, cell_type_id, dataset_citations, dataset_publications, deposition_date, description, grid_preparation, https_prefix, key_photo_thumbnail_url, key_photo_url, last_modified_date, organism_name, organism_taxid, other_setup, related_database_entries, related_database_links, release_date, s3_prefix, sample_preparation, sample_type, tissue_id, tissue_name, title'
+        == '"dataset" is an object and can\'t be compared directly. Please filter on one of its scalar attributes instead: id, cell_component_id, cell_component_name, cell_name, cell_strain_id, cell_strain_name, cell_type_id, dataset_citations, dataset_publications, deposition_date, description, grid_preparation, https_prefix, key_photo_thumbnail_url, key_photo_url, last_modified_date, organism_name, organism_taxid, other_setup, related_database_entries, related_database_links, release_date, s3_prefix, sample_preparation, sample_type, tissue_id, tissue_name, title'
     )

--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -1,0 +1,31 @@
+from cryoet_data_portal import Run, Tomogram
+import pytest
+
+
+def test_basic_filters(client) -> None:
+    # Make sure we can filter on local and remote fields
+    runs = Run.find(client, [Run.name == "RUN1"])
+    assert len(runs) == 1
+    assert runs[0].name == "RUN1"
+
+    tomograms = Tomogram.find(
+        client, [Tomogram.tomogram_voxel_spacing.run.name == "RUN1"]
+    )
+    assert len(tomograms) == 1
+    assert tomograms[0].tomogram_voxel_spacing.run.name == "RUN1"
+
+
+def test_filter_on_object_raises_exceptions(client) -> None:
+    # Make sure we can't filter on relationship fields directly
+    with pytest.raises(Exception) as exc_info:
+        Run.find(client, [Run.tomogram_voxel_spacings.annotations == 20001])
+    assert (
+        exc_info.value.args[0]
+        == '"tomogram_voxel_spacings.annotations" is an object and can\'t be filtered directly. Please filter on one of its scalar attributes instead: annotation_method, annotation_publication, annotation_software, confidence_precision, confidence_recall, deposition_date, ground_truth_status, ground_truth_used, https_metadata_path, id, is_curator_recommended, last_modified_date, object_count, object_description, object_id, object_name, object_state, release_date, s3_metadata_path, tomogram_voxel_spacing_id'
+    )
+    with pytest.raises(Exception) as exc_info:
+        Run.find(client, [Run.dataset == 20001])
+    assert (
+        exc_info.value.args[0]
+        == '"dataset" is an object and can\'t be filtered directly. Please filter on one of its scalar attributes instead: id, cell_component_id, cell_component_name, cell_name, cell_strain_id, cell_strain_name, cell_type_id, dataset_citations, dataset_publications, deposition_date, description, grid_preparation, https_prefix, key_photo_thumbnail_url, key_photo_url, last_modified_date, organism_name, organism_taxid, other_setup, related_database_entries, related_database_links, release_date, s3_prefix, sample_preparation, sample_type, tissue_id, tissue_name, title'
+    )


### PR DESCRIPTION
Fix for #626 , raise an exception when filtering on invalid fields.