### PR TITLE
fix: List all shapes available for a given annotation.

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -259,7 +259,7 @@ export function AnnotationTable() {
 
         cell: ({ getValue }) => (
           <TableCell width={AnnotationTableWidths.files}>
-            {getValue().at(0)?.shape_type ?? '--'}
+            {[...new Set(getValue().map((item) => item.shape_type))].join(', ')}
           </TableCell>
         ),
       }),

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -259,7 +259,9 @@ export function AnnotationTable() {
 
         cell: ({ getValue }) => (
           <TableCell width={AnnotationTableWidths.files}>
-            {[...new Set(getValue().map((item) => item.shape_type))].join(', ') ?? '--'}
+            {[...new Set(getValue().map((item) => item.shape_type))].join(
+              ', ',
+            ) ?? '--'}
           </TableCell>
         ),
       }),

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -259,7 +259,7 @@ export function AnnotationTable() {
 
         cell: ({ getValue }) => (
           <TableCell width={AnnotationTableWidths.files}>
-            {[...new Set(getValue().map((item) => item.shape_type))].join(', ')}
+            {[...new Set(getValue().map((item) => item.shape_type))].join(', ') ?? '--'}
           </TableCell>
         ),
       }),


### PR DESCRIPTION
Fixes #638 

An annotation may contain files that represent multiple different annotation shapes, we should list all unique shape types available for an annotation. This produces a result like so:

![Screenshot 2024-04-15 at 12 00 39 PM](https://github.com/chanzuckerberg/cryoet-data-portal/assets/475208/3e9964a6-d4a6-4062-b682-e58ed0d936ab)
