### PR TITLE
fix: annotation table primary author sort

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -149,7 +149,7 @@ const GET_RUN_BY_ID_QUERY = gql(`
             shape_type
           }
 
-          authors(order_by: { primary_annotator_status: asc }) {
+          authors(order_by: { author_list_order: asc }) {
             name
             primary_annotator_status
             corresponding_author_status


### PR DESCRIPTION
#635

Fixes issue with primary author not being visible on the annotation table

## Demo

<img width="314" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/7a3539ab-cba8-46ab-8b7e-12e3e24c0bea">
