### PR TITLE
ci: fix download modal e2e tests

### DIFF
--- a/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
+++ b/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
@@ -12,6 +12,7 @@ import {
   constructDialogUrl,
   expectClickToSwitchTab,
   expectTabSelected,
+  expectUrlsToMatch,
   getIconButton,
   validateDialogOpen,
 } from './utils'
@@ -149,7 +150,9 @@ export function testSingleRunDownloadDialog() {
         const expectedUrl = constructDialogUrl(SINGLE_RUN_URL, {
           step: DownloadStep.Configure,
           config: DownloadConfig.AllAnnotations,
+          fileFormat: 'mrc',
         })
+
         await page.waitForURL(expectedUrl.href)
       })
 
@@ -254,6 +257,7 @@ export function testSingleRunDownloadDialog() {
           step: DownloadStep.Download,
           config: DownloadConfig.AllAnnotations,
           tab: DownloadTab.AWS,
+          fileFormat: 'mrc',
         })
         await goTo(page, initialUrl.href)
         const dialog = await validateDialogOpen(
@@ -267,8 +271,10 @@ export function testSingleRunDownloadDialog() {
           step: DownloadStep.Download,
           config: DownloadConfig.AllAnnotations,
           tab: DownloadTab.API,
+          fileFormat: 'mrc',
         })
-        await page.waitForURL(expectedUrl.href)
+
+        expectUrlsToMatch(page.url(), expectedUrl.href)
       })
 
       test('should change tabs from api to aws on click', async ({ page }) => {
@@ -276,6 +282,7 @@ export function testSingleRunDownloadDialog() {
           step: DownloadStep.Download,
           config: DownloadConfig.AllAnnotations,
           tab: DownloadTab.API,
+          fileFormat: 'mrc',
         })
         await goTo(page, initialUrl.href)
         const dialog = await validateDialogOpen(
@@ -289,8 +296,10 @@ export function testSingleRunDownloadDialog() {
           step: DownloadStep.Download,
           config: DownloadConfig.AllAnnotations,
           tab: DownloadTab.AWS,
+          fileFormat: 'mrc',
         })
-        await page.waitForURL(expectedUrl.href)
+
+        expectUrlsToMatch(page.url(), expectedUrl.href)
       })
 
       test('should copy from aws tab', async ({ page, browserName }) => {
@@ -485,6 +494,7 @@ export function testSingleRunDownloadDialog() {
             const initialUrl = constructDialogUrl(SINGLE_RUN_URL, {
               step: DownloadStep.Download,
               config: DownloadConfig.Tomogram,
+              fileFormat: 'mrc',
               tab,
             })
 
@@ -517,6 +527,7 @@ export function testSingleRunDownloadDialog() {
               step: DownloadStep.Download,
               config: DownloadConfig.Tomogram,
               tab: fromTab,
+              fileFormat: 'mrc',
             })
             await goTo(page, initialUrl.href)
             const dialog = await validateDialogOpen(
@@ -530,8 +541,10 @@ export function testSingleRunDownloadDialog() {
               step: DownloadStep.Download,
               config: DownloadConfig.Tomogram,
               tab: toTab,
+              fileFormat: 'mrc',
             })
-            await page.waitForURL(expectedUrl.href)
+
+            expectUrlsToMatch(page.url(), expectedUrl.href)
           })
         })
       })
@@ -557,6 +570,7 @@ export function testSingleRunDownloadDialog() {
             processing: tomogram.processing,
           },
           tab: DownloadTab.AWS,
+          fileFormat: 'mrc',
         })
         await goTo(page, initialUrl.href)
 

--- a/frontend/packages/data-portal/e2e/dialogs/utils.ts
+++ b/frontend/packages/data-portal/e2e/dialogs/utils.ts
@@ -33,11 +33,13 @@ export function constructDialogUrl(
     step,
     config,
     tomogram,
+    fileFormat,
   }: {
     tab?: string
     step?: string
     config?: string
     tomogram?: { sampling: number; processing: string }
+    fileFormat?: string
   },
 ): URL {
   const expectedUrl = new URL(url)
@@ -60,7 +62,22 @@ export function constructDialogUrl(
     params.append(QueryParams.DownloadTab, tab)
   }
 
+  if (fileFormat) {
+    params.append(QueryParams.FileFormat, fileFormat)
+  }
+
   return expectedUrl
+}
+
+export function expectUrlsToMatch(urlStr1: string, urlStr2: string) {
+  const url1 = new URL(urlStr1)
+  const url2 = new URL(urlStr2)
+
+  expect(url1.pathname).toBe(url2.pathname)
+
+  url1.searchParams.forEach((value, key) =>
+    expect(url2.searchParams.get(key)).toBe(value),
+  )
 }
 
 export async function expectTabSelected(


### PR DESCRIPTION
Fixes E2E tests for the download modal after changes to the download modal added the file format parameter in #591 and #589