### PR TITLE
fix: Updating annotation object shape type query

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
@@ -82,10 +82,8 @@ const GET_DATASETS_DATA_QUERY = gql(`
       object_name
     }
 
-    object_shape_types: annotations {
-      files(distinct_on: shape_type) {
-        shape_type
-      }
+    object_shape_types: annotation_files(distinct_on: shape_type) {
+      shape_type
     }
   }
 `)

--- a/frontend/packages/data-portal/app/hooks/useDatasets.ts
+++ b/frontend/packages/data-portal/app/hooks/useDatasets.ts
@@ -35,12 +35,8 @@ export function useDatasets() {
 
       objectNames: data.object_names.map((value) => value.object_name),
 
-      objectShapeTypes: Array.from(
-        new Set(
-          data.object_shape_types.flatMap((value) =>
-            value.files.map((file) => file.shape_type),
-          ),
-        ),
+      objectShapeTypes: data.object_shape_types.map(
+        (value) => value.shape_type,
       ),
     }),
     [


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/660

### Changes introduced
- Optimizes by removing the join for fetching annotation shape types. 