### PR TITLE
perf: measure getBrowseDatasets query perf

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
@@ -1,4 +1,5 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { performance } from 'perf_hooks'
 import { match } from 'ts-pattern'
 
 import { gql } from 'app/__generated__'
@@ -382,7 +383,9 @@ export async function getBrowseDatasets({
   params?: URLSearchParams
   query?: string
 }) {
-  return client.query({
+  const start = performance.now()
+
+  const results = await client.query({
     query: GET_DATASETS_DATA_QUERY,
     variables: {
       filter: getFilter(getFilterState(params), query),
@@ -391,4 +394,10 @@ export async function getBrowseDatasets({
       order_by_dataset: orderBy,
     },
   })
+
+  const end = performance.now()
+  // eslint-disable-next-line no-console
+  console.log(`getBrowseDatasets query perf: ${end - start}ms`)
+
+  return results
 }


### PR DESCRIPTION
#660

Adds perf measurement to `getBrowseDatasets` query and logs it using the prefix `getBrowseDatasets query perf`