### PR TITLE
fix: Adding liveliness_timeout and readiness_timeout 

### DIFF
--- a/frontend/.happy/terraform/envs/dev/main.tf
+++ b/frontend/.happy/terraform/envs/dev/main.tf
@@ -19,17 +19,19 @@ module "stack" {
   }
   services = {
     frontend = {
-      health_check_path     = "/"
-      name                  = "frontend"
-      path                  = "/*"
-      port                  = 8080
-      desired_count         = 1
-      priority              = 0
-      service_type          = "EXTERNAL"
-      success_codes         = "200-499"
-      memory                = "2000Mi"
-      cpu                   = "2000m"
-      initial_delay_seconds = 100
+      health_check_path         = "/"
+      name                      = "frontend"
+      path                      = "/*"
+      port                      = 8080
+      desired_count             = 1
+      priority                  = 0
+      service_type              = "EXTERNAL"
+      success_codes             = "200-499"
+      memory                    = "2000Mi"
+      cpu                       = "2000m"
+      initial_delay_seconds     = 100
+      liveness_timeout_seconds  = 30
+      readiness_timeout_seconds = 30
     }
   }
   create_dashboard = false

--- a/frontend/.happy/terraform/envs/dev/main.tf
+++ b/frontend/.happy/terraform/envs/dev/main.tf
@@ -5,7 +5,7 @@ data "aws_ssm_parameter" "graphql_endpoint" {
 }
 
 module "stack" {
-  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=jgadling/optional-datadog"
+  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=happy-stack-eks-v4.31.0"
   image_tag        = var.image_tag
   stack_name       = var.stack_name
   k8s_namespace    = var.k8s_namespace

--- a/frontend/.happy/terraform/envs/prod/main.tf
+++ b/frontend/.happy/terraform/envs/prod/main.tf
@@ -19,16 +19,18 @@ module "stack" {
   }
   services = {
     frontend = {
-      health_check_path     = "/"
-      name                  = "frontend"
-      path                  = "/*"
-      port                  = 8080
-      priority              = 0
-      service_type          = "EXTERNAL"
-      success_codes         = "200-499"
-      memory                = "2000Mi"
-      cpu                   = "2000m"
-      initial_delay_seconds = 100
+      health_check_path         = "/"
+      name                      = "frontend"
+      path                      = "/*"
+      port                      = 8080
+      priority                  = 0
+      service_type              = "EXTERNAL"
+      success_codes             = "200-499"
+      memory                    = "2000Mi"
+      cpu                       = "2000m"
+      initial_delay_seconds     = 100
+      liveness_timeout_seconds  = 30
+      readiness_timeout_seconds = 30
     }
   }
   create_dashboard = false

--- a/frontend/.happy/terraform/envs/prod/main.tf
+++ b/frontend/.happy/terraform/envs/prod/main.tf
@@ -5,7 +5,7 @@ data "aws_ssm_parameter" "graphql_endpoint" {
 }
 
 module "stack" {
-  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=ref=happy-stack-eks-v4.31.0"
+  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=happy-stack-eks-v4.31.0"
   image_tag        = var.image_tag
   stack_name       = var.stack_name
   k8s_namespace    = var.k8s_namespace

--- a/frontend/.happy/terraform/envs/prod/main.tf
+++ b/frontend/.happy/terraform/envs/prod/main.tf
@@ -5,7 +5,7 @@ data "aws_ssm_parameter" "graphql_endpoint" {
 }
 
 module "stack" {
-  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=jgadling/optional-datadog"
+  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=ref=happy-stack-eks-v4.31.0"
   image_tag        = var.image_tag
   stack_name       = var.stack_name
   k8s_namespace    = var.k8s_namespace

--- a/frontend/.happy/terraform/envs/staging/main.tf
+++ b/frontend/.happy/terraform/envs/staging/main.tf
@@ -19,17 +19,19 @@ module "stack" {
   }
   services = {
     frontend = {
-      health_check_path     = "/"
-      name                  = "frontend"
-      path                  = "/*"
-      port                  = 8080
-      desired_count         = 1
-      priority              = 0
-      service_type          = "EXTERNAL"
-      success_codes         = "200-499"
-      memory                = "2000Mi"
-      cpu                   = "2000m"
-      initial_delay_seconds = 100
+      health_check_path         = "/"
+      name                      = "frontend"
+      path                      = "/*"
+      port                      = 8080
+      desired_count             = 1
+      priority                  = 0
+      service_type              = "EXTERNAL"
+      success_codes             = "200-499"
+      memory                    = "2000Mi"
+      cpu                       = "2000m"
+      initial_delay_seconds     = 100
+      liveness_timeout_seconds  = 30
+      readiness_timeout_seconds = 30
     }
   }
   create_dashboard = false

--- a/frontend/.happy/terraform/envs/staging/main.tf
+++ b/frontend/.happy/terraform/envs/staging/main.tf
@@ -5,7 +5,7 @@ data "aws_ssm_parameter" "graphql_endpoint" {
 }
 
 module "stack" {
-  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=ref=happy-stack-eks-v4.31.0"
+  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=happy-stack-eks-v4.31.0"
   image_tag        = var.image_tag
   stack_name       = var.stack_name
   k8s_namespace    = var.k8s_namespace

--- a/frontend/.happy/terraform/envs/staging/main.tf
+++ b/frontend/.happy/terraform/envs/staging/main.tf
@@ -5,7 +5,7 @@ data "aws_ssm_parameter" "graphql_endpoint" {
 }
 
 module "stack" {
-  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=jgadling/optional-datadog"
+  source           = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-stack-eks?ref=ref=happy-stack-eks-v4.31.0"
   image_tag        = var.image_tag
   stack_name       = var.stack_name
   k8s_namespace    = var.k8s_namespace


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/662

### Changes Introduced
- Updating the happy-stack-eks reference to the current latest version as the referenced branch no longer exists. 
- Adding explicit values for the liveliness_timeout and readiness_timeout to help the `Client.Timeout exceeded while awaiting headers` errors. 