### PR TITLE
fix: file format race condition

### DIFF
--- a/frontend/packages/data-portal/app/components/Download/FileFormatDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/Download/FileFormatDropdown.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 import { I18n } from 'app/components/I18n'
 import { Select, SelectOption } from 'app/components/Select'
 import { useDownloadModalQueryParamState } from 'app/hooks/useDownloadModalQueryParamState'
-import { useEffectOnce } from 'app/hooks/useEffectOnce'
 import { useI18n } from 'app/hooks/useI18n'
 import { I18nKeys } from 'app/types/i18n'
 import { cns } from 'app/utils/cns'
@@ -50,13 +49,6 @@ export function FileFormatDropdown({
       })),
     [matchingFileFormats, t],
   )
-
-  // set initial file format
-  useEffectOnce(() => {
-    if (fileFormat === null) {
-      setFileFormat(defaultFormat, true)
-    }
-  })
 
   const selectedFormat = fileFormat ?? defaultFormat
 

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -336,6 +336,11 @@ export function AnnotationTable() {
                       runId: run.id,
                       annotationId: annotation.id,
                       objectShapeType: annotation.shape_type,
+                      fileFormat: annotation.files
+                        .filter(
+                          (file) => file.shape_type === annotation.shape_type,
+                        )
+                        .at(0)?.format,
                     })
                   }
                   startIcon={

--- a/frontend/packages/data-portal/app/hooks/useDownloadModalQueryParamState.ts
+++ b/frontend/packages/data-portal/app/hooks/useDownloadModalQueryParamState.ts
@@ -141,6 +141,7 @@ export function useDownloadModalQueryParamState() {
         [QueryParams.DownloadStep]: DownloadStep.Configure,
         [QueryParams.AnnotationId]: String(payload.annotationId),
         [QueryParams.ObjectShapeType]: payload.objectShapeType,
+        [QueryParams.FileFormat]: payload.fileFormat,
       })
     },
     [getPlausiblePayload, plausible, setDownloadParams],
@@ -196,6 +197,7 @@ export function useDownloadModalQueryParamState() {
         [QueryParams.DownloadConfig]: DownloadConfig.Tomogram,
         [QueryParams.TomogramSampling]: initialTomogramSampling,
         [QueryParams.TomogramProcessing]: initialTomogramProcessing,
+        [QueryParams.FileFormat]: 'mrc',
       }),
     [setDownloadParams],
   )
@@ -206,6 +208,7 @@ export function useDownloadModalQueryParamState() {
         [QueryParams.DownloadConfig]: DownloadConfig.AllAnnotations,
         [QueryParams.TomogramSampling]: null,
         [QueryParams.TomogramProcessing]: null,
+        [QueryParams.FileFormat]: null,
       }),
     [setDownloadParams],
   )


### PR DESCRIPTION
There was an issue with calling `setFileFormat` in a use effect because it would have a race condition with other concurrent code that is also updating the URL parameters. The fix is to remove the effect and update the file format in the same code that is replacing the other URL parameters 