### PR TITLE
fix: remove fileFormat param when toggling Download All Annotations

### DIFF
--- a/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
+++ b/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
@@ -154,7 +154,6 @@ export function testSingleRunDownloadDialog() {
         const expectedUrl = constructDialogUrl(SINGLE_RUN_URL, {
           step: DownloadStep.Configure,
           config: DownloadConfig.AllAnnotations,
-          fileFormat: 'mrc',
         })
 
         await page.waitForURL(expectedUrl.href)


### PR DESCRIPTION
Accidentally added a file format param to the test checking when clicking on `Download All Annotations`