### PR TITLE
fix: run header full width for firefox

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -92,7 +92,7 @@ export function RunHeader() {
       onMoreInfoClick={() => toggleDrawer(MetadataDrawerId.Run)}
       title={run.name}
       renderHeader={({ moreInfo }) => (
-        <div className="flex gap-sds-xxl p-sds-xl">
+        <div className="flex flex-auto gap-sds-xxl p-sds-xl">
           <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m flex-shrink-0 flex items-center">
             {keyPhotoURL ? (
               <Link to={keyPhotoURL}>


### PR DESCRIPTION
#683

Fixes the issue with the run header not being full width for firefox

## Demo

<img width="1728" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/7e348422-a129-4923-858e-26a1cc99d049">
