### PR TITLE
ci: fix e2e tests

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -78,6 +78,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: playwright-report
+          name: html-report-${{ matrix.browser }}-${{ matrix.shardCurrent }}-${{ matrix.shardTotal }}
           path: frontend/packages/data-portal/playwright-report/
           retention-days: 1


### PR DESCRIPTION
#743

Fixes the E2E tests temporarily by switching to the test runner to use `macos`. The root cause for this is still uncertain, but it's work will be tracked in #756.

This also fixes the archive generation for the playwright report by using the correct path 

## Demo

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/9237537451

<img width="770" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/654d0518-f7bc-4238-a46e-3ed84b9f9195">
