### PR TITLE
ci: notify slack for prod success / failure

### DIFF
--- a/.github/create-slack-payload.js
+++ b/.github/create-slack-payload.js
@@ -1,0 +1,76 @@
+async function createSlackPayload({ prNumber, passed, runId }) {
+  // Get changelog from main directly so we can get latest entry in the changelog.
+  const changelogResponse = await fetch(
+    'https://raw.githubusercontent.com/chanzuckerberg/cryoet-data-portal/main/frontend/CHANGELOG.md'
+  )
+  const changelog = await changelogResponse.text()
+  const [, version, date] = /## \[(.*)\]\(.*\) \((.*)\)/.exec(changelog)
+  const changelogHash = `${version.replaceAll('.', '')}-${date}`
+
+  return JSON.stringify({
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `Data Portal *v${version}* ${
+            passed
+              ? 'was deployed successfully :blobtada:'
+              : 'deploy failed! :blob-sad:'
+          }`,
+        },
+      },
+
+      {
+        type: 'rich_text',
+        elements: [
+          {
+            type: 'rich_text_list',
+            style: 'bullet',
+            elements: [
+              // Only show changelog if deployment is successful
+              ...(passed
+                ? [
+                    {
+                      type: 'rich_text_section',
+                      elements: [
+                        {
+                          type: 'link',
+                          url: `https://github.com/chanzuckerberg/cryoet-data-portal/blob/main/frontend/CHANGELOG.md#${changelogHash}`,
+                          text: 'Changelog',
+                        },
+                      ],
+                    },
+                  ]
+                : []),
+
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'link',
+                    url: `https://github.com/chanzuckerberg/cryoet-data-portal/pull/${prNumber}`,
+                    text: 'Release PR',
+                  },
+                ],
+              },
+
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'link',
+                    url: `https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/${runId}`,
+                    text: 'GitHub Run',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+}
+
+module.exports = createSlackPayload

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -194,3 +194,35 @@ jobs:
     secrets: inherit
     with:
       environment: prod
+
+  notify-slack:
+    name: Notify slack channel
+    runs-on: ubuntu-latest
+    needs: [run-prod-e2e-test, find-frontend-release-pr]
+    if: always()
+
+    steps:
+      - name: checkout repo for tagging
+        uses: actions/checkout@v4
+
+      - name: Create slack payload
+        id: slack-payload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const createSlackPayload = require('./.github/create-slack-payload')
+            const pr = ${{ needs.find-frontend-release-pr.outputs.pr }}
+
+            return createSlackPayload({
+              passed: '${{ needs.run-prod-e2e-test.result }}' === 'success',
+              prNumber: pr.number,
+              runId: '${{ github.run_id }}',
+            })
+
+      - name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: ${{ fromJson(steps.slack-payload.outputs.result) }}


### PR DESCRIPTION
#483

Updates the prod workflow to slack notify the `#team-sci-imaging-data-portal` channel when a production deploy is successful or if it failed via Hubert 🤖 

## Demos

### Success

<img width="399" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/0217b3f3-e8db-4005-9f66-cbd3cc688a6d">

### Failure

<img width="330" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/73119a2d-1cca-475f-a8ad-f9229b0e05be">

## Links

<img width="492" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/7e66cb46-5b03-47f1-9038-f65a097269ee">

<img width="486" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/f458e7b9-79b3-4d5e-a441-6cb9e41838c4">

<img width="506" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/479605b8-529e-4260-ad22-2f071091e9eb">
