### PR TITLE
fix: restore object count

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/AnnotationObjectTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationObjectTable.tsx
@@ -33,6 +33,11 @@ export function AnnotationObjectTable() {
             </Link>
           ),
         },
+
+        {
+          label: t('objectCount'),
+          values: [annotation.object_count],
+        },
         {
           label: t('objectShapeType'),
           values: [annotation.shape_type],


### PR DESCRIPTION
#732

Adds the object count row that was missing from the annotation metadata drawer

## Demos

<img width="496" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/62479537-ff0e-4402-b670-58bd4af45ff5">
