### PR TITLE
fix: adds colon for meets all label

### DIFF
--- a/frontend/packages/data-portal/app/components/DatasetFilter/IncludedContentsFilterSection.tsx
+++ b/frontend/packages/data-portal/app/components/DatasetFilter/IncludedContentsFilterSection.tsx
@@ -85,7 +85,7 @@ export function IncludedContentsFilterSection() {
 
       const meetsAll = document.createElement('div')
       meetsAll.id = MEETS_ALL_LABEL_ID
-      meetsAll.textContent = t('meetsAll')
+      meetsAll.textContent = `${t('meetsAll')}:`
 
       filterButtonNode?.insertAdjacentElement('afterend', meetsAll)
     } else if (!showMeetsAll && meetsAllNode) {


### PR DESCRIPTION
#186

Adds a `:` character for the meets all label

## Demos

### Before

<img width="178" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/341983f7-0019-4e1a-8fbe-ec6b82ee3442">

### After

<img width="167" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/9a4a1055-2092-4f62-bdd9-5c7b8860bb1b">
