### PR TITLE
ci: skip slack notify when no PR is found

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -208,6 +208,7 @@ jobs:
       - name: Create slack payload
         id: slack-payload
         uses: actions/github-script@v7
+        if: needs.find-frontend-release-pr.outputs.pr != ''
         with:
           script: |
             const createSlackPayload = require('./.github/create-slack-payload')


### PR DESCRIPTION
If there is no release PR open, we should skip notifying slack since there isn't a build failure