### PR TITLE
ci: fix skip slack notify if condition

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -199,7 +199,7 @@ jobs:
     name: Notify slack channel
     runs-on: ubuntu-latest
     needs: [run-prod-e2e-test, find-frontend-release-pr]
-    if: always()
+    if: needs.find-frontend-release-pr.outputs.pr != '' && !cancelled()
 
     steps:
       - name: checkout repo for tagging
@@ -208,7 +208,6 @@ jobs:
       - name: Create slack payload
         id: slack-payload
         uses: actions/github-script@v7
-        if: needs.find-frontend-release-pr.outputs.pr != ''
         with:
           script: |
             const createSlackPayload = require('./.github/create-slack-payload')


### PR DESCRIPTION
#811 fixes an issue with slack notify not being skipped when the release PR doesn't exist, but it only partially fixes the issue. even though the payload step is skipped, the notify slack step is not skipped

rather than add an additional condition on the notify slack step, we can skip the job altogether by updating the conditional. instead of always running via `always()`, the job will now only run if:

1. the release PR exists
2. the workflow succeeds or fails, cancels are skipped 