### PR TITLE
fix: Merge query filters properly

### DIFF
--- a/client/python/cryoet_data_portal/pyproject.toml
+++ b/client/python/cryoet_data_portal/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies= [
     "requests",
     "boto3",
+    "deepmerge",
     "gql[requests]",
     "tqdm",
 ]

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -2,6 +2,7 @@ import functools
 from datetime import datetime, timezone
 from importlib import import_module
 from typing import Any, Dict, Iterable, Optional
+from deepmerge import always_merger
 
 from ._client import Client
 
@@ -90,12 +91,10 @@ class BaseField(GQLField):
         return value
 
 
-class StringField(BaseField):
-    ...
+class StringField(BaseField): ...
 
 
-class IntField(BaseField):
-    ...
+class IntField(BaseField): ...
 
 
 class DateField(BaseField):
@@ -106,12 +105,10 @@ class DateField(BaseField):
             )
 
 
-class BooleanField(BaseField):
-    ...
+class BooleanField(BaseField): ...
 
 
-class FloatField(BaseField):
-    ...
+class FloatField(BaseField): ...
 
 
 class QueryChain(GQLField):
@@ -289,7 +286,7 @@ class Model:
         filters = {}
         if query_filters:
             for expression in query_filters:
-                filters.update(expression.to_gql())
+                filters = always_merger.merge(filters, expression.to_gql())
         return client.find(cls, filters)
 
     @classmethod

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -2,6 +2,7 @@ import functools
 from datetime import datetime, timezone
 from importlib import import_module
 from typing import Any, Dict, Iterable, Optional
+
 from deepmerge import always_merger
 
 from ._client import Client
@@ -91,10 +92,12 @@ class BaseField(GQLField):
         return value
 
 
-class StringField(BaseField): ...
+class StringField(BaseField):
+    ...
 
 
-class IntField(BaseField): ...
+class IntField(BaseField):
+    ...
 
 
 class DateField(BaseField):
@@ -105,10 +108,12 @@ class DateField(BaseField):
             )
 
 
-class BooleanField(BaseField): ...
+class BooleanField(BaseField):
+    ...
 
 
-class FloatField(BaseField): ...
+class FloatField(BaseField):
+    ...
 
 
 class QueryChain(GQLField):

--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -17,6 +17,24 @@ def test_basic_filters(client) -> None:
     assert tomograms[0].tomogram_voxel_spacing.run.name == "RUN1"
 
 
+def test_filter_merge(client) -> None:
+    # Make sure our GQL filters get merged instead of letting the longest-path
+    # queries overwrite shorter paths.
+    runs = Run.find(client, [Run.name == "RUN1"])
+    assert len(runs) == 1
+    assert runs[0].name == "RUN1"
+
+    tomograms = Tomogram.find(
+        client,
+        [
+            Tomogram.tomogram_voxel_spacing.run.name == "RUN001",
+            Tomogram.tomogram_voxel_spacing.run.dataset.id == 20002,
+        ],
+    )
+    assert len(tomograms) == 1
+    assert tomograms[0].tomogram_voxel_spacing.run.name == "RUN001"
+
+
 def test_filter_on_object_raises_exceptions(client) -> None:
     # Make sure we can't filter on relationship fields directly
     with pytest.raises(Exception) as exc_info:


### PR DESCRIPTION
Using ```somedict.update()``` to merge filters was overwriting deeply nested filters instead of combining them. The `deepmerge` library can merge nested structures better.