### PR TITLE
ci: fix slack notify on failure

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -12,15 +12,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  run-staging-e2e-test:
-    name: Run e2e test on staging
-    uses: ./.github/workflows/frontend-e2e-tests.yml
-    secrets: inherit
-    # The variable IS_DEPLOY_ALLOWED is used to manually gate the prod deploys
-    if: vars.IS_DEPLOY_ALLOWED == 'true'
-    with:
-      environment: staging
-
   find-frontend-release-pr:
     concurrency:
       group: create-frontend-release-${{ github.ref }}
@@ -61,6 +52,15 @@ jobs:
             })
 
             return pr
+
+  run-staging-e2e-test:
+    name: Run e2e test on staging
+    uses: ./.github/workflows/frontend-e2e-tests.yml
+    secrets: inherit
+    # The variable IS_DEPLOY_ALLOWED is used to manually gate the prod deploys
+    if: vars.IS_DEPLOY_ALLOWED == 'true'
+    with:
+      environment: staging
 
   tag-frontend-release:
     concurrency:


### PR DESCRIPTION
Fixes issue with slack notify not working on failure. This is because the notify job requires the `find-frontend-release-pr`, but in some cases the E2E tests fail resulting in the `find-frontend-release-pr` job not running. Moving it to the top ensures that we have the data before we start the E2E tests.

## Demo

<img width="345" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/c7cfe995-cf33-4df6-b8f6-77c18cf67d38">

<img width="376" alt="image" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/2176050/7854d114-0062-446b-a3f3-b4624ac2e58c">
