### PR TITLE
ci: upgrade pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install PNPM
         if: steps.changes.outputs.frontend == 'true'
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.9.0
           run_install: false

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20.8.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.9.0
           run_install: false
@@ -104,7 +104,7 @@ jobs:
           node-version: 20.8.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.9.0
           run_install: false

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20.8.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.9.0
           run_install: false


### PR DESCRIPTION
fixes issue with pnpm setup failing during E2E tests:

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/9785017665/job/27017150862?pr=807