### PR TITLE
fix: change Empiar to EMPIAR

### DIFF
--- a/frontend/packages/data-portal/app/i18n.ts
+++ b/frontend/packages/data-portal/app/i18n.ts
@@ -69,7 +69,7 @@ export const i18n = {
   documentation: 'Documentation',
   downloadDataset: 'Download Dataset',
   emdb: 'EMDB',
-  empiarID: 'Empiar ID',
+  empiarID: 'EMPIAR ID',
   energyFilter: 'Energy Filter',
   excellent: 'Excellent',
   false: 'False',

--- a/frontend/packages/data-portal/e2e/browseDatasetFilter.test.ts
+++ b/frontend/packages/data-portal/e2e/browseDatasetFilter.test.ts
@@ -49,7 +49,7 @@ testMultiInputFilter({
     },
     {
       queryParam: QueryParams.EmpiarId,
-      label: 'Empiar ID',
+      label: 'EMPIAR ID',
       valueKey: 'empiarId',
     },
     {

--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -117,7 +117,7 @@
   "downloadTomogram": "Download Tomogram",
   "downloadWillSaveToCurrentDirectory": "Download will save to your current directory. To change save destination, change the current directory in your terminal before continuing.",
   "emdb": "EMDB",
-  "empiarID": "Empiar ID",
+  "empiarID": "EMPIAR ID",
   "energyFilter": "Energy Filter",
   "estimatedDownloadSize": "Estimated Download Size",
   "excellent": "Excellent",


### PR DESCRIPTION
Resolves #802 

Change Empiar to EMPIAR because this is an acronym.

<img width="966" alt="Screenshot 2024-07-05 at 9 19 08 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/5c6adb4e-2bdb-4633-8688-c2a5ff3ce875">
<img width="266" alt="Screenshot 2024-07-05 at 9 18 57 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/7128d0fe-c185-4cb7-aba3-b88deac0d95d">
