### PR TITLE
chore: Fix metadata test

### DIFF
--- a/frontend/packages/data-portal/e2e/metadataDrawer/testMetadataDrawer.ts
+++ b/frontend/packages/data-portal/e2e/metadataDrawer/testMetadataDrawer.ts
@@ -104,10 +104,17 @@ export function testMetadataDrawer({
               `Test for ${label} to have value ${value}`,
             ).toContainText(`${value}`)
           } else {
-            await expect(
-              cells.last(),
-              `Test for ${label} to be empty`,
-            ).toContainText('--')
+            if (data.metadata.groundTruthStatus) {
+              await expect(
+                cells.last(),
+                `Test for ${label} to be empty`,
+              ).toContainText('--')
+            } else {
+              await expect(
+                cells.last(),
+                `Test for ${label} to be "Not Applicable"`,
+              ).toContainText('Not Applicable')
+            }
           }
         }
       })

--- a/frontend/packages/data-portal/e2e/metadataDrawer/testMetadataDrawer.ts
+++ b/frontend/packages/data-portal/e2e/metadataDrawer/testMetadataDrawer.ts
@@ -4,7 +4,7 @@ import { expect, Page, test } from '@playwright/test'
 import { getApolloClient } from 'e2e/apollo'
 import { E2E_CONFIG, translations } from 'e2e/constants'
 import { goTo } from 'e2e/filters/utils'
-import { isArray, isNumber } from 'lodash-es'
+import { isArray } from 'lodash-es'
 
 import { TestIds } from 'app/constants/testIds'
 
@@ -90,6 +90,7 @@ export function testMetadataDrawer({
           const label = translations[key as keyof typeof translations]
           const cells = drawer.locator(`tr:has-text("${label}") td`)
 
+          // Array:
           if (isArray(value)) {
             const nodeValue = await cells.last().innerText()
             expect(
@@ -98,24 +99,32 @@ export function testMetadataDrawer({
                 ', ',
               )}`,
             ).toBe(true)
-          } else if (isNumber(value) || value) {
+            continue
+          }
+          // String or number:
+          if (value !== null) {
             await expect(
               cells.last(),
               `Test for ${label} to have value ${value}`,
             ).toContainText(`${value}`)
-          } else {
-            if (data.metadata.groundTruthStatus) {
-              await expect(
-                cells.last(),
-                `Test for ${label} to be empty`,
-              ).toContainText('--')
-            } else {
-              await expect(
-                cells.last(),
-                `Test for ${label} to be "Not Applicable"`,
-              ).toContainText('Not Applicable')
-            }
+            continue
           }
+          // Empty because N/A:
+          if (
+            data.metadata.groundTruthStatus &&
+            ['groundTruthUsed', 'precision', 'recall'].includes(key)
+          ) {
+            await expect(
+              cells.last(),
+              `Test for ${label} to be "Not Applicable"`,
+            ).toContainText('Not Applicable')
+            continue
+          }
+          // Empty:
+          await expect(
+            cells.last(),
+            `Test for ${label} to be empty`,
+          ).toContainText('--')
         }
       })
     },

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -57,6 +57,9 @@ module.exports = {
       (rule) => rule.selector !== 'ForOfStatement',
     ),
 
+    // Allow use of continue in loops
+    'no-continue': 'off',
+
     // Sometimes it's safe to call async functions and not handle their errors.
     '@typescript-eslint/no-misused-promises': 'off',
 


### PR DESCRIPTION
The new `runId` shows "Not Applicable" for some metadata fields instead of "--".

Also add a lint exception to allow `continue` (I believe it's the Airbnb plugin that's disallowing it, but supposedly their company also disallows loops entirely...) since in this case it reduced nesting, but lmk if we want to keep it banned.