### PR TITLE
fix: Increase width for tilt series quality score column.

### DIFF
--- a/frontend/packages/data-portal/app/constants/table.ts
+++ b/frontend/packages/data-portal/app/constants/table.ts
@@ -34,7 +34,7 @@ export const AnnotationTableWidths = {
 export const RunTableWidths = {
   photo: PHOTO_COLUMN_WIDTH,
   name: { min: 400 },
-  tiltSeriesQuality: { min: 120, max: 210 },
+  tiltSeriesQuality: { min: 183, max: 210 },
   annotatedObjects: { min: 250, max: 400 },
   actions: { min: 150, max: 200 },
 }


### PR DESCRIPTION
Resolves #686 

The column width seems to be responsive based on the cell content rather than the header content.  To combat this, this PR sets a min width on the Tilt Series Quality Score to ensure the header displays.  It's unclear to me whether setting a larger minimum value will have negative impacts on making the table responsive (is that a priority?).  The responsive issue would apply to all of the columns, so this change likely doesn't make anything worse.

<img width="1258" alt="Screenshot 2024-07-08 at 2 34 23 PM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/e6a2a86c-4f4f-4aad-9193-d3f48cf4d36e">
