### PR TITLE
ci: fix metadata drawer e2e

### DIFF
--- a/frontend/packages/data-portal/e2e/metadataDrawer/utils.ts
+++ b/frontend/packages/data-portal/e2e/metadataDrawer/utils.ts
@@ -131,6 +131,10 @@ export function getAnnotationTestMetdata(
     objectState: annotation.object_state,
     objectDescription: annotation.object_description,
 
+    // Ground truth annotations show N/A for precision and recall because they
+    // represent the correct or true labels for a dataset. Non ground truth
+    // annotations have these fields because they are compared against a ground
+    // truth annotation.
     precision: getGroundTruthField(annotation.confidence_precision ?? '--'),
     recall: getGroundTruthField(annotation.confidence_recall ?? '--'),
     groundTruthStatus: getBoolString(annotation.ground_truth_status),


### PR DESCRIPTION
Follow up from #839 that fixes the metadata drawer E2E by passing the correct test data based on the ground truth status. 

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/9862017314