### PR TITLE
fix: stop capitalizing annotation object display

### DIFF
--- a/frontend/packages/data-portal/app/components/AnnotatedObjectsList.tsx
+++ b/frontend/packages/data-portal/app/components/AnnotatedObjectsList.tsx
@@ -43,10 +43,7 @@ export function AnnotatedObjectsList({
           val1.toLowerCase().localeCompare(val2.toLocaleLowerCase()),
         )
         .map((obj) => (
-          <li
-            className="text-ellipsis line-clamp-1 break-all capitalize"
-            key={obj}
-          >
+          <li className="text-ellipsis line-clamp-1 break-all" key={obj}>
             {obj}
           </li>
         ))

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -216,7 +216,7 @@ export function AnnotationTable() {
 
         cell: ({ getValue }) => (
           <TableCell width={AnnotationTableWidths.objectName}>
-            <div className="line-clamp-2 text-ellipsis capitalize">
+            <div className="line-clamp-2 text-ellipsis">
               {getValue()}
             </div>
           </TableCell>

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -216,9 +216,7 @@ export function AnnotationTable() {
 
         cell: ({ getValue }) => (
           <TableCell width={AnnotationTableWidths.objectName}>
-            <div className="line-clamp-2 text-ellipsis">
-              {getValue()}
-            </div>
+            <div className="line-clamp-2 text-ellipsis">{getValue()}</div>
           </TableCell>
         ),
       }),

--- a/frontend/packages/data-portal/app/components/RunFilter/RunFilter.tsx
+++ b/frontend/packages/data-portal/app/components/RunFilter/RunFilter.tsx
@@ -29,7 +29,7 @@ export function RunFilter() {
       <FilterSection title={t('annotationMetadata')} border={false}>
         <AnnotatedObjectNameFilter
           allObjectNames={objectNames}
-          label={t('annotatedObjectName')}
+          label={t('objectName')}
         />
         <AnnotatedObjectShapeTypeFilter
           allObjectShapeTypes={objectShapeTypes}

--- a/frontend/packages/data-portal/e2e/singleDatasetFilter.test.ts
+++ b/frontend/packages/data-portal/e2e/singleDatasetFilter.test.ts
@@ -13,7 +13,7 @@ testGroundTruthAnnotationFilter({
 })
 
 testSingleSelectFilter({
-  label: translations.annotatedObjectName,
+  label: translations.objectName,
   queryParam: QueryParams.ObjectName,
   url: SINGLE_DATASET_URL,
   validateTable: validateRunsTable,

--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -17,7 +17,6 @@
   "alignedTiltSeriesBinning": "Aligned Tilt Series Binning",
   "all": "All",
   "allDatasets": "All Datasets",
-  "annotatedObjectName": "Annotated Object Name",
   "annotatedObjects": "Annotated Objects",
   "annotationAuthor": "Annotation Author",
   "annotationAuthors": "Annotation Authors",


### PR DESCRIPTION
Resolves #603 
Resolves #860 

We were capitalizing the annotation object names.  Now we're not.
<img width="1277" alt="Screenshot 2024-07-10 at 9 50 55 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/08372cef-4579-488e-adf4-729b9d07c3bc">
<img width="1278" alt="Screenshot 2024-07-10 at 9 51 04 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/4164c14a-af3b-4f26-a68d-56b9bb55a291">
<img width="1285" alt="Screenshot 2024-07-10 at 9 52 24 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/48363172-5f38-4ba2-90f9-44e04fa1218e">

The annotation filter should say "Object Name" rather than "Annotated Object Name"
<img width="563" alt="Screenshot 2024-07-10 at 10 28 20 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/a0769e2b-60dc-4dec-90e2-94ba248c2d14">
<img width="413" alt="Screenshot 2024-07-10 at 10 28 05 AM" src="https://github.com/chanzuckerberg/cryoet-data-portal/assets/109251328/3690aaf3-1ab3-478d-83a5-53bd00a85d59">


