### PR TITLE
docs: Fix contribution form link in Data Organization page

### DIFF
--- a/docs/cryoet_data_portal_docsite_data.md
+++ b/docs/cryoet_data_portal_docsite_data.md
@@ -1,6 +1,6 @@
 # Data Organization
 
-The Data Portal is organized in a hierarchical structure. We welcome contributions to the Portal. [Use this form](https://airtable.com/apppmytRJXoXYTO9w/shr5UxgeQcUTSGyiY?prefill_Event=Portal&hide_Event=true) to express interest in adding your data to the Portal.
+The Data Portal is organized in a hierarchical structure. We welcome contributions to the Portal. [Use this form](https://airtable.com/apppmytRJXoXYTO9w/shr5UxgeQcUTSGyiY?prefill_Event=Portal\&hide_Event=true) to express interest in adding your data to the Portal.
 
 ## Overview
 


### PR DESCRIPTION
The '&' in the link wasn't escaped. I randomly tried something, and it seemed to work in the preview, but please check it out if it's the right thing to do!