### PR TITLE
fix: CSS tweaks to labels

### DIFF
--- a/frontend/packages/data-portal/app/components/Filters/Filters.module.css
+++ b/frontend/packages/data-portal/app/components/Filters/Filters.module.css
@@ -3,6 +3,8 @@
 .boolean {
   :global(.MuiTypography-root) {
     font-size: theme('fontSize.sds-body-s') !important;
+    font-weight: theme('fontWeight.semibold') !important;
+    color: theme('colors.sds-gray.500') !important;
   }
 }
 

--- a/frontend/packages/data-portal/app/components/InlineMetadata.tsx
+++ b/frontend/packages/data-portal/app/components/InlineMetadata.tsx
@@ -29,7 +29,7 @@ export function InlineMetadata({
             className={cns(
               'font-semibold',
               subheader
-                ? 'text-sds-gray-600 tracking-sds-caps text-sds-caps-xxs leading-sds-caps-xxs'
+                ? 'text-sds-gray-600 tracking-sds-body-xxs text-sds-caps-xxs leading-sds-caps-xxs'
                 : 'text-sds-body-xxs leading-sds-body-xxs',
               uppercase && 'uppercase',
               subheader && uppercase && 'tracking-sds-caps',


### PR DESCRIPTION
https://github.com/chanzuckerberg/cryoet-data-portal/issues/864

- Makes non-uppercase `<InlineMetadata>`s not use caps style.
- Makes ground truth filter text style match that of other filters.