### PR TITLE
fix: Don't add annotation rows for shape types that are filtered out

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -14,7 +14,6 @@ import { MAX_PER_PAGE } from 'app/constants/pagination'
 import { AnnotationTableWidths } from 'app/constants/table'
 import { TestIds } from 'app/constants/testIds'
 import { useDownloadModalQueryParamState } from 'app/hooks/useDownloadModalQueryParamState'
-import { useFilter } from 'app/hooks/useFilter'
 import { useI18n } from 'app/hooks/useI18n'
 import { useIsLoading } from 'app/hooks/useIsLoading'
 import {
@@ -83,7 +82,6 @@ export function AnnotationTable() {
   const { toggleDrawer } = useMetadataDrawer()
   const { setActiveAnnotation } = useAnnotation()
   const { t } = useI18n()
-  const { annotation: annotationFilter } = useFilter()
 
   const { openAnnotationDownloadModal } = useDownloadModalQueryParamState()
 
@@ -397,7 +395,7 @@ export function AnnotationTable() {
           }))
         }),
       ) as Annotation[],
-    [run.annotation_table, annotationFilter.objectShapeTypes],
+    [run.annotation_table],
   )
 
   return (

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -380,15 +380,8 @@ export function AnnotationTable() {
 
           // Some annotations have files with different shape types. We display each shape type as a separate row.
           // This loops through the files and adds an annotation for each shape type.
+          // If the shape type is filtered out, the files will not be returned in the 'run' object
           const files = annotation.files.filter((file) => {
-            // If the shape type is filtered out, don't add an annotation for it
-            if (
-              annotationFilter.objectShapeTypes.length > 0 &&
-              !annotationFilter.objectShapeTypes.includes(file.shape_type)
-            ) {
-              return false
-            }
-
             // If the shape type has already been added, don't add another annotation for it
             if (shapeTypeSet.has(file.shape_type)) {
               return false

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -14,6 +14,7 @@ import { MAX_PER_PAGE } from 'app/constants/pagination'
 import { AnnotationTableWidths } from 'app/constants/table'
 import { TestIds } from 'app/constants/testIds'
 import { useDownloadModalQueryParamState } from 'app/hooks/useDownloadModalQueryParamState'
+import { useFilter } from 'app/hooks/useFilter'
 import { useI18n } from 'app/hooks/useI18n'
 import { useIsLoading } from 'app/hooks/useIsLoading'
 import {
@@ -82,6 +83,7 @@ export function AnnotationTable() {
   const { toggleDrawer } = useMetadataDrawer()
   const { setActiveAnnotation } = useAnnotation()
   const { t } = useI18n()
+  const { annotation: annotationFilter } = useFilter()
 
   const { openAnnotationDownloadModal } = useDownloadModalQueryParamState()
 
@@ -376,7 +378,18 @@ export function AnnotationTable() {
         data.annotations.flatMap((annotation) => {
           const shapeTypeSet = new Set<string>()
 
+          // Some annotations have files with different shape types. We display each shape type as a separate row.
+          // This loops through the files and adds an annotation for each shape type.
           const files = annotation.files.filter((file) => {
+            // If the shape type is filtered out, don't add an annotation for it
+            if (
+              annotationFilter.objectShapeTypes.length > 0 &&
+              !annotationFilter.objectShapeTypes.includes(file.shape_type)
+            ) {
+              return false
+            }
+
+            // If the shape type has already been added, don't add another annotation for it
             if (shapeTypeSet.has(file.shape_type)) {
               return false
             }
@@ -391,7 +404,7 @@ export function AnnotationTable() {
           }))
         }),
       ) as Annotation[],
-    [run.annotation_table],
+    [run.annotation_table, annotationFilter.objectShapeTypes],
   )
 
   return (


### PR DESCRIPTION
Resolves #891 

In order to display a separate annotation row for each shape type, we expand the list of annotations on the frontend.  This adds a check to the expansion function for whether the shape type is filtered out.

![filter-fix](https://github.com/user-attachments/assets/e41bebbd-1edc-45e8-8cb4-b2f36a6e51d6)
