### PR TITLE
fix: Use match with substring for exception check in client tests

### DIFF
--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -37,7 +37,7 @@ def test_filter_merge(client) -> None:
 
 def test_filter_on_object_raises_exceptions(client) -> None:
     # Make sure we can't filter on relationship fields directly
-    match = 'is an object and can\'t be compared directly.'
+    match = "is an object and can't be compared directly."
     with pytest.raises(Exception, match=match):
         Run.find(client, [Run.tomogram_voxel_spacings.annotations == 20001])
     with pytest.raises(Exception, match=match):

--- a/client/python/cryoet_data_portal/tests/test_filters.py
+++ b/client/python/cryoet_data_portal/tests/test_filters.py
@@ -37,15 +37,8 @@ def test_filter_merge(client) -> None:
 
 def test_filter_on_object_raises_exceptions(client) -> None:
     # Make sure we can't filter on relationship fields directly
-    with pytest.raises(Exception) as exc_info:
+    match = 'is an object and can\'t be compared directly.'
+    with pytest.raises(Exception, match=match):
         Run.find(client, [Run.tomogram_voxel_spacings.annotations == 20001])
-    assert (
-        exc_info.value.args[0]
-        == '"tomogram_voxel_spacings.annotations" is an object and can\'t be compared directly. Please filter on one of its scalar attributes instead: annotation_method, annotation_publication, annotation_software, confidence_precision, confidence_recall, deposition_date, ground_truth_status, ground_truth_used, https_metadata_path, id, is_curator_recommended, last_modified_date, object_count, object_description, object_id, object_name, object_state, release_date, s3_metadata_path, tomogram_voxel_spacing_id'
-    )
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match=match):
         Run.find(client, [Run.dataset == 20001])
-    assert (
-        exc_info.value.args[0]
-        == '"dataset" is an object and can\'t be compared directly. Please filter on one of its scalar attributes instead: id, cell_component_id, cell_component_name, cell_name, cell_strain_id, cell_strain_name, cell_type_id, dataset_citations, dataset_publications, deposition_date, description, grid_preparation, https_prefix, key_photo_thumbnail_url, key_photo_url, last_modified_date, organism_name, organism_taxid, other_setup, related_database_entries, related_database_links, release_date, s3_prefix, sample_preparation, sample_type, tissue_id, tissue_name, title'
-    )

--- a/client/python/cryoet_data_portal/tests/test_infra/.gitignore
+++ b/client/python/cryoet_data_portal/tests/test_infra/.gitignore
@@ -1,0 +1,2 @@
+# Created as part of test infra
+test_file


### PR DESCRIPTION
The `test_filter_on_object_raises_exceptions` test previously checked for an exception to have an exact test message. The schema must have changed a little since these were first written, so now these tests fail.

Instead of trying to match the whole string and updating it every time the schema changes, I used the `match` keyword to match a common substring that should be more stable.

I also ignored a small test file that's created as part of the test setup.

