### PR TITLE
feat: Refactor <TablePageLayout> to support multiple tabs

### DIFF
--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -97,28 +97,28 @@ function TablePageTabContent({
   filteredCount,
   table,
   noResults,
-  pageQueryParamKey: pageQueryParam = QueryParams.Page,
+  pageQueryParamKey = QueryParams.Page,
   totalCount,
   countLabel,
 }: TableLayoutTab) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const pageQueryParamValue = +(searchParams.get(pageQueryParam) ?? '1')
+  const pageQueryParamValue = +(searchParams.get(pageQueryParamKey) ?? '1')
 
   useEffect(() => {
     if (Math.ceil(filteredCount / MAX_PER_PAGE) < pageQueryParamValue) {
       setSearchParams(
         (prev) => {
-          prev.delete(pageQueryParam)
+          prev.delete(pageQueryParamKey)
           return prev
         },
         { replace: true },
       )
     }
-  }, [filteredCount, pageQueryParamValue, pageQueryParam, setSearchParams])
+  }, [filteredCount, pageQueryParamKey, pageQueryParamValue, setSearchParams])
 
   function setPage(nextPage: number) {
     setSearchParams((prev) => {
-      prev.set(pageQueryParam, `${nextPage}`)
+      prev.set(pageQueryParamKey, `${nextPage}`)
       return prev
     })
   }

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -1,6 +1,7 @@
 import { Pagination } from '@czi-sds/components'
 import { useSearchParams } from '@remix-run/react'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { toNumber } from 'lodash-es'
+import { ReactNode, useEffect, useMemo } from 'react'
 
 import { TABLE_PAGE_LAYOUT_LOG_ID } from 'app/constants/error'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
@@ -45,7 +46,8 @@ export function TablePageLayout({
   downloadModal,
   drawers,
 }: TablePageLayoutProps) {
-  const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = tabs[toNumber(searchParams.get(QueryParams.TableTab) ?? 0)]
 
   return (
     <>
@@ -58,11 +60,14 @@ export function TablePageLayout({
           <>
             {tabsTitle && <div className="text-sds-header-l">{tabsTitle}</div>}
             <Tabs
-              value={activeTabIndex}
-              onChange={(tabIndex: number) => {
-                setActiveTabIndex(tabIndex)
+              value={activeTab.title}
+              onChange={(tabTitle: string) => {
+                setSearchParams((prev) => {
+                  prev.set(QueryParams.TableTab, tabTitle)
+                  return prev
+                })
               }}
-              tabs={tabs.map((tab, i) => ({
+              tabs={tabs.map((tab) => ({
                 label: (
                   <>
                     <span>{tab.title}</span>
@@ -71,12 +76,12 @@ export function TablePageLayout({
                     </span>
                   </>
                 ),
-                value: i,
+                value: tab.title,
               }))}
             />
           </>
         )}
-        <TablePageTabContent {...tabs[activeTabIndex]} />
+        <TablePageTabContent {...activeTab} />
 
         {drawers}
       </div>

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -47,15 +47,8 @@ export function TablePageLayout({
 }: TablePageLayoutProps) {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
 
-  const contextValue = useMemo<LayoutContextValue>(
-    () => ({
-      hasFilters: tabs[activeTabIndex].filterPanel !== undefined,
-    }),
-    [activeTabIndex, tabs],
-  )
-
   return (
-    <LayoutContext.Provider value={contextValue}>
+    <>
       {downloadModal}
 
       <div className="flex flex-col flex-auto">
@@ -87,7 +80,7 @@ export function TablePageLayout({
 
         {drawers}
       </div>
-    </LayoutContext.Provider>
+    </>
   )
 }
 
@@ -124,74 +117,83 @@ function TablePageTabContent({
     })
   }
 
+  const contextValue = useMemo<LayoutContextValue>(
+    () => ({
+      hasFilters: filterPanel !== undefined,
+    }),
+    [filterPanel],
+  )
+
   return (
-    <div className="flex flex-auto">
-      {filterPanel && (
-        <div
-          className={cns(
-            'flex flex-col flex-shrink-0 w-[235px]',
-            'border-t border-r border-sds-gray-300',
-          )}
-        >
-          {filterPanel}
-        </div>
-      )}
-
-      <div
-        className={cns(
-          'flex flex-col flex-auto screen-2040:items-center',
-          'pt-sds-xl pb-sds-xxl',
-          'border-t border-sds-gray-300',
-          'overflow-x-scroll max-w-full',
-        )}
-      >
-        <div
-          className={cns(
-            'flex flex-col flex-auto w-full',
-
-            // Translate to the left by half the filter panel width to align with the header
-            filterPanel && 'screen-2040:translate-x-[-100px] max-w-content',
-          )}
-        >
-          <div className="px-sds-xl flex items-center gap-x-sds-xl">
-            <p className="text-sds-header-l leading-sds-header-l font-semibold">
-              {title}
-            </p>
-
-            <TableCount
-              filteredCount={filteredCount}
-              totalCount={totalCount}
-              type={countLabel}
-            />
-          </div>
-
-          <ErrorBoundary logId={TABLE_PAGE_LAYOUT_LOG_ID}>
-            <div className="overflow-x-scroll">{table}</div>
-          </ErrorBoundary>
-
-          <div className="px-sds-xl">
-            {filteredCount === 0 && noResults}
-
-            {filteredCount > MAX_PER_PAGE && (
-              <div
-                className="w-full flex justify-center mt-sds-xxl"
-                data-testid={TestIds.Pagination}
-              >
-                <Pagination
-                  currentPage={page}
-                  pageSize={MAX_PER_PAGE}
-                  totalCount={
-                    totalCount === filteredCount ? totalCount : filteredCount
-                  }
-                  onNextPage={() => setPage(page + 1)}
-                  onPreviousPage={() => setPage(page - 1)}
-                  onPageChange={(nextPage) => setPage(nextPage)}
-                />
-              </div>
+    <LayoutContext.Provider value={contextValue}>
+      <div className="flex flex-auto">
+        {filterPanel && (
+          <div
+            className={cns(
+              'flex flex-col flex-shrink-0 w-[235px]',
+              'border-t border-r border-sds-gray-300',
             )}
+          >
+            {filterPanel}
+          </div>
+        )}
+
+        <div
+          className={cns(
+            'flex flex-col flex-auto screen-2040:items-center',
+            'pt-sds-xl pb-sds-xxl',
+            'border-t border-sds-gray-300',
+            'overflow-x-scroll max-w-full',
+          )}
+        >
+          <div
+            className={cns(
+              'flex flex-col flex-auto w-full',
+
+              // Translate to the left by half the filter panel width to align with the header
+              filterPanel && 'screen-2040:translate-x-[-100px] max-w-content',
+            )}
+          >
+            <div className="px-sds-xl flex items-center gap-x-sds-xl">
+              <p className="text-sds-header-l leading-sds-header-l font-semibold">
+                {title}
+              </p>
+
+              <TableCount
+                filteredCount={filteredCount}
+                totalCount={totalCount}
+                type={countLabel}
+              />
+            </div>
+
+            <ErrorBoundary logId={TABLE_PAGE_LAYOUT_LOG_ID}>
+              <div className="overflow-x-scroll">{table}</div>
+            </ErrorBoundary>
+
+            <div className="px-sds-xl">
+              {filteredCount === 0 && noResults}
+
+              {filteredCount > MAX_PER_PAGE && (
+                <div
+                  className="w-full flex justify-center mt-sds-xxl"
+                  data-testid={TestIds.Pagination}
+                >
+                  <Pagination
+                    currentPage={page}
+                    pageSize={MAX_PER_PAGE}
+                    totalCount={
+                      totalCount === filteredCount ? totalCount : filteredCount
+                    }
+                    onNextPage={() => setPage(page + 1)}
+                    onPreviousPage={() => setPage(page - 1)}
+                    onPageChange={(nextPage) => setPage(nextPage)}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </LayoutContext.Provider>
   )
 }

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -48,10 +48,7 @@ export function TablePageLayout({
   const [searchParams, setSearchParams] = useSearchParams()
 
   const activeTabTitle = searchParams.get(QueryParams.TableTab)
-  const activeTab =
-    activeTabTitle !== null
-      ? tabs.find((tab) => tab.title === activeTabTitle) ?? tabs[0]
-      : tabs[0]
+  const activeTab = tabs.find((tab) => tab.title === activeTabTitle) ?? tabs[0]
 
   return (
     <>

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -1,66 +1,57 @@
 import { Pagination } from '@czi-sds/components'
 import { useSearchParams } from '@remix-run/react'
-import { ReactNode, useEffect, useMemo } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 
 import { TABLE_PAGE_LAYOUT_LOG_ID } from 'app/constants/error'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
+import { QueryParams } from 'app/constants/query'
 import { TestIds } from 'app/constants/testIds'
 import { LayoutContext, LayoutContextValue } from 'app/context/Layout.context'
 import { cns } from 'app/utils/cns'
 
 import { ErrorBoundary } from './ErrorBoundary'
 import { TableCount } from './Table/TableCount'
+import { Tabs } from './Tabs'
 
-export function TablePageLayout({
-  downloadModal,
-  drawers,
-  filteredCount,
-  filters: filterPanel,
-  header,
-  noResults,
-  table,
-  title,
-  totalCount,
-  type,
-}: {
+export interface TablePageLayoutProps {
+  header?: ReactNode
+
+  tabs: TableLayoutTab[] // If there is only 1 tab, the tab selector will not show.
+  tabsTitle?: string
+
   downloadModal?: ReactNode
   drawers?: ReactNode
-  filteredCount: number
-  filters?: ReactNode
-  header?: ReactNode
-  noResults?: ReactNode
-  table: ReactNode
+}
+
+export interface TableLayoutTab {
   title: string
+
+  filterPanel?: ReactNode
+  filteredCount: number
+
+  table: ReactNode
+  noResults?: ReactNode
+  pageQueryParam?: string
+
   totalCount: number
-  type: string
-}) {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const page = +(searchParams.get('page') ?? '1')
+  countLabel: string // e.g. "objects" in "1 of 3 objects".
+}
 
-  useEffect(() => {
-    if (Math.ceil(filteredCount / MAX_PER_PAGE) < page) {
-      setSearchParams(
-        (prev) => {
-          prev.delete('page')
-          return prev
-        },
-        { replace: true },
-      )
-    }
-  }, [filteredCount, page, setSearchParams])
-
-  function setPage(nextPage: number) {
-    setSearchParams((prev) => {
-      prev.set('page', `${nextPage}`)
-      return prev
-    })
-  }
+/** Standard page structure for browsing + filtering list(s) of objects. */
+export function TablePageLayout({
+  header,
+  tabs,
+  tabsTitle,
+  downloadModal,
+  drawers,
+}: TablePageLayoutProps) {
+  const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
 
   const contextValue = useMemo<LayoutContextValue>(
     () => ({
-      hasFilters: !!filterPanel,
+      hasFilters: tabs[activeTabIndex].filterPanel !== undefined,
     }),
-    [filterPanel],
+    [activeTabIndex, tabs],
   )
 
   return (
@@ -70,79 +61,137 @@ export function TablePageLayout({
       <div className="flex flex-col flex-auto">
         {header}
 
-        <div className="flex flex-auto">
-          {filterPanel && (
-            <div
-              className={cns(
-                'flex flex-col flex-shrink-0 w-[235px]',
-                'border-t border-r border-sds-gray-300',
-              )}
-            >
-              {filterPanel}
-            </div>
-          )}
-
-          <div
-            className={cns(
-              'flex flex-col flex-auto screen-2040:items-center',
-              'pt-sds-xl pb-sds-xxl',
-              'border-t border-sds-gray-300',
-              'overflow-x-scroll max-w-full',
-            )}
-          >
-            <div
-              className={cns(
-                'flex flex-col flex-auto w-full',
-
-                // Translate to the left by half the filter panel width to align with the header
-                filterPanel && 'screen-2040:translate-x-[-100px] max-w-content',
-              )}
-            >
-              <div className="px-sds-xl flex items-center gap-x-sds-xl">
-                <p className="text-sds-header-l leading-sds-header-l font-semibold">
-                  {title}
-                </p>
-
-                <TableCount
-                  filteredCount={filteredCount}
-                  totalCount={totalCount}
-                  type={type}
-                />
-              </div>
-
-              <ErrorBoundary logId={TABLE_PAGE_LAYOUT_LOG_ID}>
-                <div className="overflow-x-scroll">{table}</div>
-              </ErrorBoundary>
-
-              <div className="px-sds-xl">
-                {filteredCount === 0 && noResults}
-
-                {filteredCount > MAX_PER_PAGE && (
-                  <div
-                    className="w-full flex justify-center mt-sds-xxl"
-                    data-testid={TestIds.Pagination}
-                  >
-                    <Pagination
-                      currentPage={page}
-                      pageSize={MAX_PER_PAGE}
-                      totalCount={
-                        totalCount === filteredCount
-                          ? totalCount
-                          : filteredCount
-                      }
-                      onNextPage={() => setPage(page + 1)}
-                      onPreviousPage={() => setPage(page - 1)}
-                      onPageChange={(nextPage) => setPage(nextPage)}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
+        {tabs.length > 1 && (
+          <>
+            {tabsTitle && <div className="text-sds-header-l">{tabsTitle}</div>}
+            <Tabs
+              value={activeTabIndex}
+              onChange={(tabIndex: number) => {
+                setActiveTabIndex(tabIndex)
+              }}
+              tabs={tabs.map((tab, i) => ({
+                label: (
+                  <>
+                    <span>{tab.title}</span>
+                    <span className="text-sds-gray-500 ml-[24px]">
+                      {tab.filteredCount}
+                    </span>
+                  </>
+                ),
+                value: i,
+              }))}
+            />
+          </>
+        )}
+        <TablePageLayoutTab {...tabs[activeTabIndex]} />
 
         {drawers}
       </div>
     </LayoutContext.Provider>
+  )
+}
+
+/** Table + filter panel for 1 tab. */
+function TablePageLayoutTab({
+  title,
+  filterPanel,
+  filteredCount,
+  table,
+  noResults,
+  pageQueryParam = QueryParams.Page,
+  totalCount,
+  countLabel,
+}: TableLayoutTab) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = +(searchParams.get(pageQueryParam) ?? '1')
+
+  useEffect(() => {
+    if (Math.ceil(filteredCount / MAX_PER_PAGE) < page) {
+      setSearchParams(
+        (prev) => {
+          prev.delete(pageQueryParam)
+          return prev
+        },
+        { replace: true },
+      )
+    }
+  }, [filteredCount, page, pageQueryParam, setSearchParams])
+
+  function setPage(nextPage: number) {
+    setSearchParams((prev) => {
+      prev.set(pageQueryParam, `${nextPage}`)
+      return prev
+    })
+  }
+
+  return (
+    <div className="flex flex-auto">
+      {filterPanel && (
+        <div
+          className={cns(
+            'flex flex-col flex-shrink-0 w-[235px]',
+            'border-t border-r border-sds-gray-300',
+          )}
+        >
+          {filterPanel}
+        </div>
+      )}
+
+      <div
+        className={cns(
+          'flex flex-col flex-auto screen-2040:items-center',
+          'pt-sds-xl pb-sds-xxl',
+          'border-t border-sds-gray-300',
+          'overflow-x-scroll max-w-full',
+        )}
+      >
+        <div
+          className={cns(
+            'flex flex-col flex-auto w-full',
+
+            // Translate to the left by half the filter panel width to align with the header
+            filterPanel && 'screen-2040:translate-x-[-100px] max-w-content',
+          )}
+        >
+          <div className="px-sds-xl flex items-center gap-x-sds-xl">
+            <p className="text-sds-header-l leading-sds-header-l font-semibold">
+              {title}
+            </p>
+
+            <TableCount
+              filteredCount={filteredCount}
+              totalCount={totalCount}
+              type={countLabel}
+            />
+          </div>
+
+          <ErrorBoundary logId={TABLE_PAGE_LAYOUT_LOG_ID}>
+            <div className="overflow-x-scroll">{table}</div>
+          </ErrorBoundary>
+
+          <div className="px-sds-xl">
+            {filteredCount === 0 && noResults}
+
+            {filteredCount > MAX_PER_PAGE && (
+              <div
+                className="w-full flex justify-center mt-sds-xxl"
+                data-testid={TestIds.Pagination}
+              >
+                <Pagination
+                  currentPage={page}
+                  pageSize={MAX_PER_PAGE}
+                  totalCount={
+                    totalCount === filteredCount ? totalCount : filteredCount
+                  }
+                  onNextPage={() => setPage(page + 1)}
+                  onPreviousPage={() => setPage(page - 1)}
+                  onPageChange={(nextPage) => setPage(nextPage)}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -1,6 +1,5 @@
 import { Pagination } from '@czi-sds/components'
 import { useSearchParams } from '@remix-run/react'
-import { toNumber } from 'lodash-es'
 import { ReactNode, useEffect, useMemo } from 'react'
 
 import { TABLE_PAGE_LAYOUT_LOG_ID } from 'app/constants/error'
@@ -47,7 +46,12 @@ export function TablePageLayout({
   drawers,
 }: TablePageLayoutProps) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const activeTab = tabs[toNumber(searchParams.get(QueryParams.TableTab) ?? 0)]
+
+  const activeTabTitle = searchParams.get(QueryParams.TableTab)
+  const activeTab =
+    activeTabTitle !== null
+      ? tabs.findIndex((tab) => tab.title === activeTabTitle)
+      : tabs[0]
 
   return (
     <>

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -83,7 +83,7 @@ export function TablePageLayout({
             />
           </>
         )}
-        <TablePageLayoutTab {...tabs[activeTabIndex]} />
+        <TablePageTabContent {...tabs[activeTabIndex]} />
 
         {drawers}
       </div>
@@ -91,8 +91,8 @@ export function TablePageLayout({
   )
 }
 
-/** Table + filter panel for 1 tab. */
-function TablePageLayoutTab({
+/** Table + filters for 1 tab. */
+function TablePageTabContent({
   title,
   filterPanel,
   filteredCount,

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -30,7 +30,7 @@ export interface TableLayoutTab {
 
   table: ReactNode
   noResults?: ReactNode
-  pageQueryParam?: string
+  pageQueryParamKey?: string
 
   filteredCount: number
   totalCount: number
@@ -97,15 +97,15 @@ function TablePageTabContent({
   filteredCount,
   table,
   noResults,
-  pageQueryParam = QueryParams.Page,
+  pageQueryParamKey: pageQueryParam = QueryParams.Page,
   totalCount,
   countLabel,
 }: TableLayoutTab) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const page = +(searchParams.get(pageQueryParam) ?? '1')
+  const pageQueryParamValue = +(searchParams.get(pageQueryParam) ?? '1')
 
   useEffect(() => {
-    if (Math.ceil(filteredCount / MAX_PER_PAGE) < page) {
+    if (Math.ceil(filteredCount / MAX_PER_PAGE) < pageQueryParamValue) {
       setSearchParams(
         (prev) => {
           prev.delete(pageQueryParam)
@@ -114,7 +114,7 @@ function TablePageTabContent({
         { replace: true },
       )
     }
-  }, [filteredCount, page, pageQueryParam, setSearchParams])
+  }, [filteredCount, pageQueryParamValue, pageQueryParam, setSearchParams])
 
   function setPage(nextPage: number) {
     setSearchParams((prev) => {
@@ -185,13 +185,13 @@ function TablePageTabContent({
                   data-testid={TestIds.Pagination}
                 >
                   <Pagination
-                    currentPage={page}
+                    currentPage={pageQueryParamValue}
                     pageSize={MAX_PER_PAGE}
                     totalCount={
                       totalCount === filteredCount ? totalCount : filteredCount
                     }
-                    onNextPage={() => setPage(page + 1)}
-                    onPreviousPage={() => setPage(page - 1)}
+                    onNextPage={() => setPage(pageQueryParamValue + 1)}
+                    onPreviousPage={() => setPage(pageQueryParamValue - 1)}
                     onPageChange={(nextPage) => setPage(nextPage)}
                   />
                 </div>

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -27,12 +27,12 @@ export interface TableLayoutTab {
   title: string
 
   filterPanel?: ReactNode
-  filteredCount: number
 
   table: ReactNode
   noResults?: ReactNode
   pageQueryParam?: string
 
+  filteredCount: number
   totalCount: number
   countLabel: string // e.g. "objects" in "1 of 3 objects".
 }

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -50,7 +50,7 @@ export function TablePageLayout({
   const activeTabTitle = searchParams.get(QueryParams.TableTab)
   const activeTab =
     activeTabTitle !== null
-      ? tabs.findIndex((tab) => tab.title === activeTabTitle)
+      ? tabs.find((tab) => tab.title === activeTabTitle) ?? tabs[0]
       : tabs[0]
 
   return (

--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -119,7 +119,7 @@ function TablePageTabContent({
 
   const contextValue = useMemo<LayoutContextValue>(
     () => ({
-      hasFilters: filterPanel !== undefined,
+      hasFilters: !!filterPanel,
     }),
     [filterPanel],
   )

--- a/frontend/packages/data-portal/app/components/Tabs.tsx
+++ b/frontend/packages/data-portal/app/components/Tabs.tsx
@@ -1,14 +1,15 @@
 import Tab from '@mui/material/Tab'
 import MUITabs, { TabsProps } from '@mui/material/Tabs'
+import { ReactNode } from 'react'
 
 import { cns } from 'app/utils/cns'
 
-export interface TabData<T extends string> {
-  label: string
+export interface TabData<T> {
+  label: ReactNode
   value: T
 }
 
-export function Tabs<T extends string>({
+export function Tabs<T>({
   tabs,
   value,
   onChange,
@@ -43,7 +44,7 @@ export function Tabs<T extends string>({
               ),
               selected: '!text-black',
             }}
-            key={tab.value}
+            key={String(tab.value)}
             {...tab}
           />
         ))}

--- a/frontend/packages/data-portal/app/constants/query.ts
+++ b/frontend/packages/data-portal/app/constants/query.ts
@@ -1,5 +1,6 @@
 export enum QueryParams {
   AnnotationId = 'annotation_id',
+  AnnotationsPage = 'annotations-page',
   AnnotationSoftware = 'annotation-software',
   AuthorName = 'author',
   AuthorOrcid = 'author_orcid',

--- a/frontend/packages/data-portal/app/constants/query.ts
+++ b/frontend/packages/data-portal/app/constants/query.ts
@@ -27,6 +27,7 @@ export enum QueryParams {
   ReconstructionMethod = 'reconstruction_method',
   ReconstructionSoftware = 'reconstruction_software',
   Tab = 'tab',
+  TableTab = 'table-tab',
   TiltRangeMax = 'tilt_max',
   TiltRangeMin = 'tilt_min',
   TomogramProcessing = 'tomogram-processing',

--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -15,7 +15,7 @@ import { MAX_PER_PAGE } from 'app/constants/pagination'
 import { FilterState, getFilterState } from 'app/hooks/useFilter'
 
 const GET_RUN_BY_ID_QUERY = gql(`
-  query GetRunById($id: Int, $limit: Int, $offset: Int, $filter: annotations_bool_exp, $fileFilter: annotation_files_bool_exp) {
+  query GetRunById($id: Int, $limit: Int, $annotationsOffset: Int, $filter: annotations_bool_exp, $fileFilter: annotation_files_bool_exp) {
     runs(where: { id: { _eq: $id } }) {
       id
       name
@@ -128,7 +128,7 @@ const GET_RUN_BY_ID_QUERY = gql(`
       annotation_table: tomogram_voxel_spacings {
         annotations(
           limit: $limit,
-          offset: $offset,
+          offset: $annotationsOffset,
           where: $filter,
           order_by: [
             { ground_truth_status: desc }
@@ -343,12 +343,12 @@ function getFileFilter(filterState: FilterState) {
 export async function getRunById({
   client,
   id,
-  page = 1,
+  annotationsPage,
   params = new URLSearchParams(),
 }: {
   client: ApolloClient<NormalizedCacheObject>
   id: number
-  page?: number
+  annotationsPage: number
   params?: URLSearchParams
 }): Promise<ApolloQueryResult<GetRunByIdQuery>> {
   return client.query({
@@ -356,7 +356,7 @@ export async function getRunById({
     variables: {
       id,
       limit: MAX_PER_PAGE,
-      offset: (page - 1) * MAX_PER_PAGE,
+      annotationsOffset: (annotationsPage - 1) * MAX_PER_PAGE,
       filter: getFilter(getFilterState(params)),
       fileFilter: getFileFilter(getFilterState(params)),
     },

--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -11,7 +11,6 @@ import { getBrowseDatasets } from 'app/graphql/getBrowseDatasets.server'
 import { useDatasets } from 'app/hooks/useDatasets'
 import { useFilter } from 'app/hooks/useFilter'
 import { useI18n } from 'app/hooks/useI18n'
-import { i18n } from 'app/i18n'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
@@ -52,14 +51,14 @@ export default function BrowseDatasetsPage() {
           table: <DatasetTable />,
           noResults: (
             <NoResults
-              title={i18n.filterNoResultsFound}
-              description={i18n.filterTooRestrictive}
-              actions={<Button onClick={reset}>{i18n.clearFilters}</Button>}
+              title={t('filterNoResultsFound')}
+              description={t('filterTooRestrictive')}
+              actions={<Button onClick={reset}>{t('clearFilters')}</Button>}
             />
           ),
           filteredCount: filteredDatasetCount,
           totalCount: datasetCount,
-          countLabel: i18n.datasets,
+          countLabel: t('datasets'),
         },
       ]}
     />

--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -45,19 +45,23 @@ export default function BrowseDatasetsPage() {
 
   return (
     <TablePageLayout
-      title={t('datasets')}
-      type={i18n.datasets}
-      filteredCount={filteredDatasetCount}
-      filters={<DatasetFilter />}
-      table={<DatasetTable />}
-      totalCount={datasetCount}
-      noResults={
-        <NoResults
-          title={i18n.filterNoResultsFound}
-          description={i18n.filterTooRestrictive}
-          actions={<Button onClick={reset}>{i18n.clearFilters}</Button>}
-        />
-      }
+      tabs={[
+        {
+          title: t('datasets'),
+          filterPanel: <DatasetFilter />,
+          filteredCount: filteredDatasetCount,
+          table: <DatasetTable />,
+          noResults: (
+            <NoResults
+              title={i18n.filterNoResultsFound}
+              description={i18n.filterTooRestrictive}
+              actions={<Button onClick={reset}>{i18n.clearFilters}</Button>}
+            />
+          ),
+          totalCount: datasetCount,
+          countLabel: i18n.datasets,
+        },
+      ]}
     />
   )
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -49,7 +49,6 @@ export default function BrowseDatasetsPage() {
         {
           title: t('datasets'),
           filterPanel: <DatasetFilter />,
-          filteredCount: filteredDatasetCount,
           table: <DatasetTable />,
           noResults: (
             <NoResults
@@ -58,6 +57,7 @@ export default function BrowseDatasetsPage() {
               actions={<Button onClick={reset}>{i18n.clearFilters}</Button>}
             />
           ),
+          filteredCount: filteredDatasetCount,
           totalCount: datasetCount,
           countLabel: i18n.datasets,
         },

--- a/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
@@ -56,18 +56,22 @@ export default function BrowseDepositionsPage() {
 
   return (
     <TablePageLayout
-      title={t('depositions')}
-      type={t('depositions')}
-      filteredCount={filteredDepositionCount}
-      table={<DepositionTable />}
-      totalCount={depositionCount}
-      noResults={
-        <NoResults
-          title={t('filterNoResultsFound')}
-          description={t('filterTooRestrictive')}
-          actions={<Button onClick={reset}>{t('clearFilters')}</Button>}
-        />
-      }
+      tabs={[
+        {
+          title: t('depositions'),
+          filteredCount: filteredDepositionCount,
+          table: <DepositionTable />,
+          noResults: (
+            <NoResults
+              title={t('filterNoResultsFound')}
+              description={t('filterTooRestrictive')}
+              actions={<Button onClick={reset}>{t('clearFilters')}</Button>}
+            />
+          ),
+          totalCount: depositionCount,
+          countLabel: t('depositions'),
+        },
+      ]}
     />
   )
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
@@ -59,7 +59,6 @@ export default function BrowseDepositionsPage() {
       tabs={[
         {
           title: t('depositions'),
-          filteredCount: filteredDepositionCount,
           table: <DepositionTable />,
           noResults: (
             <NoResults
@@ -68,6 +67,7 @@ export default function BrowseDepositionsPage() {
               actions={<Button onClick={reset}>{t('clearFilters')}</Button>}
             />
           ),
+          filteredCount: filteredDepositionCount,
           totalCount: depositionCount,
           countLabel: t('depositions'),
         },

--- a/frontend/packages/data-portal/app/routes/datasets.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/datasets.$id.tsx
@@ -3,12 +3,12 @@
 import { json, LoaderFunctionArgs } from '@remix-run/server-runtime'
 
 import { apolloClient } from 'app/apollo.server'
+import { TablePageLayout } from 'app/components//TablePageLayout'
 import { DatasetMetadataDrawer } from 'app/components/Dataset'
 import { DatasetHeader } from 'app/components/Dataset/DatasetHeader'
 import { RunsTable } from 'app/components/Dataset/RunsTable'
 import { DownloadModal } from 'app/components/Download'
 import { RunFilter } from 'app/components/RunFilter'
-import { TablePageLayout } from 'app/components/TablePageLayout'
 import { QueryParams } from 'app/constants/query'
 import { getDatasetById } from 'app/graphql/getDatasetById.server'
 import { useDatasetById } from 'app/hooks/useDatasetById'
@@ -51,8 +51,17 @@ export default function DatasetByIdPage() {
 
   return (
     <TablePageLayout
-      title={t('runs')}
-      type={i18n.runs}
+      header={<DatasetHeader />}
+      tabs={[
+        {
+          title: t('runs'),
+          filterPanel: <RunFilter />,
+          filteredCount: dataset.filtered_runs_count.aggregate?.count ?? 0,
+          table: <RunsTable />,
+          totalCount: dataset.runs_aggregate.aggregate?.count ?? 0,
+          countLabel: i18n.runs,
+        },
+      ]}
       downloadModal={
         <DownloadModal
           datasetId={dataset.id}
@@ -62,11 +71,6 @@ export default function DatasetByIdPage() {
         />
       }
       drawers={<DatasetMetadataDrawer />}
-      filteredCount={dataset.filtered_runs_count.aggregate?.count ?? 0}
-      header={<DatasetHeader />}
-      table={<RunsTable />}
-      totalCount={dataset.runs_aggregate.aggregate?.count ?? 0}
-      filters={<RunFilter />}
     />
   )
 }

--- a/frontend/packages/data-portal/app/routes/datasets.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/datasets.$id.tsx
@@ -56,8 +56,8 @@ export default function DatasetByIdPage() {
         {
           title: t('runs'),
           filterPanel: <RunFilter />,
-          filteredCount: dataset.filtered_runs_count.aggregate?.count ?? 0,
           table: <RunsTable />,
+          filteredCount: dataset.filtered_runs_count.aggregate?.count ?? 0,
           totalCount: dataset.runs_aggregate.aggregate?.count ?? 0,
           countLabel: i18n.runs,
         },

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -68,6 +68,7 @@ export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
       QueryParams.ObjectShapeType,
       QueryParams.MethodType,
       QueryParams.AnnotationSoftware,
+      QueryParams.AnnotationsPage,
     ],
   })
 }

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -185,7 +185,7 @@ export default function RunByIdPage() {
           filterPanel: <AnnotationFilter />,
           filteredCount,
           table: <AnnotationTable />,
-          pageQueryParam: QueryParams.AnnotationsPage,
+          pageQueryParamKey: QueryParams.AnnotationsPage,
           totalCount,
           countLabel: i18n.annotations,
         },

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -7,13 +7,13 @@ import { useMemo } from 'react'
 import { match } from 'ts-pattern'
 
 import { apolloClient } from 'app/apollo.server'
+import { TablePageLayout } from 'app/components//TablePageLayout'
 import { AnnotationFilter } from 'app/components/AnnotationFilter/AnnotationFilter'
 import { DownloadModal } from 'app/components/Download'
 import { RunHeader } from 'app/components/Run'
 import { AnnotationDrawer } from 'app/components/Run/AnnotationDrawer'
 import { AnnotationTable } from 'app/components/Run/AnnotationTable'
 import { RunMetadataDrawer } from 'app/components/Run/RunMetadataDrawer'
-import { TablePageLayout } from 'app/components/TablePageLayout'
 import { QueryParams } from 'app/constants/query'
 import { getRunById } from 'app/graphql/getRunById.server'
 import { useDownloadModalQueryParamState } from 'app/hooks/useDownloadModalQueryParamState'
@@ -175,8 +175,18 @@ export default function RunByIdPage() {
 
   return (
     <TablePageLayout
-      title={t('annotations')}
-      type={i18n.annotations}
+      header={<RunHeader />}
+      tabs={[
+        {
+          title: t('annotations'),
+          filterPanel: <AnnotationFilter />,
+          filteredCount,
+          table: <AnnotationTable />,
+          pageQueryParam: QueryParams.AnnotationsPage,
+          totalCount,
+          countLabel: i18n.annotations,
+        },
+      ]}
       downloadModal={
         <DownloadModal
           activeAnnotation={activeAnnotation}
@@ -229,11 +239,6 @@ export default function RunByIdPage() {
           <AnnotationDrawer />
         </>
       }
-      filters={<AnnotationFilter />}
-      filteredCount={filteredCount}
-      header={<RunHeader />}
-      table={<AnnotationTable />}
-      totalCount={totalCount}
     />
   )
 }

--- a/frontend/packages/data-portal/app/routes/runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/runs.$id.tsx
@@ -36,11 +36,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 
   const url = new URL(request.url)
-  const page = +(url.searchParams.get(QueryParams.Page) ?? '1')
+  const annotationsPage = +(
+    url.searchParams.get(QueryParams.AnnotationsPage) ?? '1'
+  )
 
   const { data } = await getRunById({
     id,
-    page,
+    annotationsPage,
     client: apolloClient,
     params: url.searchParams,
   })

--- a/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
+++ b/frontend/packages/data-portal/e2e/dialogs/singleRun.ts
@@ -30,7 +30,7 @@ const TOMOTABS = [
 
 async function fetchData() {
   const client = getApolloClient()
-  return getRunById({ client, id: +E2E_CONFIG.runId })
+  return getRunById({ client, id: +E2E_CONFIG.runId, annotationsPage: 1 })
 }
 
 export function testSingleRunDownloadDialog() {

--- a/frontend/packages/data-portal/e2e/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/filters/utils.ts
@@ -217,7 +217,7 @@ export async function validateAnnotationsTable({
   client,
   page,
   params,
-  pageNumber,
+  pageNumber = 1,
   id = +E2E_CONFIG.runId,
 }: TableValidatorOptions & { id?: number }) {
   const { data } = await getRunById({

--- a/frontend/packages/data-portal/e2e/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/filters/utils.ts
@@ -224,7 +224,7 @@ export async function validateAnnotationsTable({
     client,
     params,
     id,
-    page: pageNumber,
+    annotationsPage: pageNumber,
   })
 
   await validateTable({

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/filtersActor.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/filtersActor.ts
@@ -46,7 +46,7 @@ export class FiltersActor {
   }: {
     client: ApolloClient<NormalizedCacheObject>
     id: number
-    pageNumber?: number
+    pageNumber: number
     url: string
     queryParamKey?: QueryParams
     queryParamValue: string
@@ -63,7 +63,7 @@ export class FiltersActor {
       client,
       params,
       id,
-      page: pageNumber,
+      annotationsPage: pageNumber,
     })
 
     return data
@@ -166,7 +166,7 @@ export class FiltersActor {
   }: {
     client: ApolloClient<NormalizedCacheObject>
     id: number
-    pageNumber?: number
+    pageNumber: number
     url: string
     queryParamKey?: QueryParams
     queryParamValue: string

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
@@ -36,7 +36,7 @@ export function getExpectedUrlWithQueryParams({
 export async function getAnnotationsTableTestData({
   client,
   params,
-  pageNumber,
+  pageNumber = 1,
   id = +E2E_CONFIG.runId,
 }: TableValidatorOptions & { id?: number }): Promise<
   ApolloQueryResult<GetRunByIdQuery>['data']
@@ -45,7 +45,7 @@ export async function getAnnotationsTableTestData({
     client,
     params,
     id,
-    page: pageNumber,
+    annotationsPage: pageNumber,
   })
 
   return data

--- a/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
@@ -177,6 +177,7 @@ export async function getSingleRunTestMetadata(
   const { data } = await getRunById({
     client,
     id: +E2E_CONFIG.runId,
+    annotationsPage: 1,
   })
 
   const [run] = data.runs
@@ -207,6 +208,7 @@ export async function getAnnotationTestData(
   const { data } = await getRunById({
     client,
     id: +E2E_CONFIG.runId,
+    annotationsPage: 1,
   })
 
   const [run] = data.runs

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -62,6 +62,8 @@ module.exports = {
 
     // Sometimes it's safe to call async functions and not handle their errors.
     '@typescript-eslint/no-misused-promises': 'off',
+    // Allow us to use function/variable hoisting.
+    '@typescript-eslint/no-use-before-define': 'off',
 
     'unused-imports/no-unused-imports': 'error',
     'unused-imports/no-unused-vars': [


### PR DESCRIPTION
This is to support having both Annotations and Tomograms tabs on the Runs page.
 - Adds support for a header above the tabs.
 - Uses our existing `<Tabs>` component.
   - Only shows tabs if more than 1 is specified.
 - Supports a different pagination query param per tab.
   - This changes the query param on the Runs page from `page` to `annotations-page`. In a subsequent PR I'll add `tomograms-page`. 
   - It seems like we're currently pretty far from either annotations or tomograms getting to a point where they'd actually trigger pagination, but I'd prefer this to work properly from the get-go rather than find out there's a bug later.
 - Stores the currently open tab in URL params.
 - Make a few prop names clearer.
 - Allow `<Tabs>` to take in components as labels and `number`s (i.e. indexes) as values.
 - Also enable hoisting in ESLint (which TS checks anyways).