### PR TITLE
chore: codecov failure should fail loudly

### DIFF
--- a/.github/workflows/client-python.yml
+++ b/.github/workflows/client-python.yml
@@ -89,3 +89,4 @@ jobs:
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
+          fail_ci_if_error: true


### PR DESCRIPTION
- add argument to fail loudly if codecoverage upload fails

There is a separate ticket to fix the failure https://github.com/chanzuckerberg/cryoet-data-portal/issues/945