### PR TITLE
fix: repeated annotated object names

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -251,9 +251,13 @@ export function RunHeader() {
                   {
                     label: i18n.annotatedObjects,
                     inline: true,
-                    values: run.tomogram_stats
-                      .flatMap((stats) => stats.annotations)
-                      .map((annotation) => annotation.object_name),
+                    values: Array.from(
+                      new Set(
+                        run.tomogram_stats
+                          .flatMap((stats) => stats.annotations)
+                          .map((annotation) => annotation.object_name),
+                      ),
+                    ),
                   },
                 ]}
               />


### PR DESCRIPTION
#810

Removes duplicate object names from the list using a `Set`

## Demos

### Before

<img width="1328" alt="image" src="https://github.com/user-attachments/assets/ca573fc1-8167-421e-87b4-9a3f236c8cd1">

### After

<img width="1328" alt="image" src="https://github.com/user-attachments/assets/552b3719-7050-4002-8a80-ccda0f015ac4">


