### PR TITLE
feat: add user agent to client requests

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/__init__.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/__init__.py
@@ -4,12 +4,6 @@ An API client library to facilitate use of the Cryo-Electron Tomography portal A
 For more information on the API, visit the [cryoet-data-portal repo](https://github.com/chanzuckerberg/cryoet-data-portal/)
 """
 
-try:
-    from importlib import metadata
-except ImportError:
-    # for python <=3.7
-    import importlib_metadata as metadata  # type: ignore[no-redef]
-
 from ._client import Client
 from ._models import (
     Annotation,
@@ -24,12 +18,9 @@ from ._models import (
     TomogramAuthor,
     TomogramVoxelSpacing,
 )
+from ._version import version
 
-try:
-    __version__ = metadata.version("cryoet_data_portal")
-except metadata.PackageNotFoundError:
-    # package is not installed
-    __version__ = "0.0.0-unknown"
+__version__ = version
 
 __all__ = [
     "Client",

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_client.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_client.py
@@ -28,7 +28,11 @@ class Client:
         # Use our default API URL
         if not url:
             url = "https://graphql.cryoetdataportal.cziscience.com/v1/graphql"
-        transport = RequestsHTTPTransport(url=url, retries=3, headers=USER_AGENT)
+        transport = RequestsHTTPTransport(
+            url=url,
+            retries=3,
+            headers={"User-agent": USER_AGENT},
+        )
 
         with open(
             os.path.join(

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_client.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_client.py
@@ -6,6 +6,8 @@ from gql import Client as GQLClient
 from gql.dsl import DSLQuery, DSLSchema, dsl_gql
 from gql.transport.requests import RequestsHTTPTransport
 
+from cryoet_data_portal._constants import USER_AGENT
+
 
 class Client:
     """A GraphQL Client library that can traverse all the metadata in the CryoET Data Portal
@@ -26,10 +28,7 @@ class Client:
         # Use our default API URL
         if not url:
             url = "https://graphql.cryoetdataportal.cziscience.com/v1/graphql"
-        transport = RequestsHTTPTransport(
-            url=url,
-            retries=3,
-        )
+        transport = RequestsHTTPTransport(url=url, retries=3, headers=USER_AGENT)
 
         with open(
             os.path.join(

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_constants.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_constants.py
@@ -1,0 +1,13 @@
+import sys
+
+import cryoet_data_portal
+
+# added to all http requests to identify the client for analytics
+USER_AGENT = {
+    "User-agent": ";".join(
+        [
+            f"python={sys.version_info.major}.{sys.version_info.minor}",
+            f"cryoet_data_portal_client={cryoet_data_portal.__version__}",
+        ],
+    ),
+}

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_constants.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_constants.py
@@ -1,13 +1,11 @@
 import sys
 
-import cryoet_data_portal
+from ._version import version
 
 # added to all http requests to identify the client for analytics
-USER_AGENT = {
-    "User-agent": ";".join(
-        [
-            f"python={sys.version_info.major}.{sys.version_info.minor}",
-            f"cryoet_data_portal_client={cryoet_data_portal.__version__}",
-        ],
-    ),
-}
+USER_AGENT = ";".join(
+    [
+        f"python={sys.version_info.major}.{sys.version_info.minor}",
+        f"cryoet_data_portal_client={version}",
+    ],
+)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
@@ -42,7 +42,7 @@ def download_https(
     with_progress: bool = True,
 ):
     dest_path = get_destination_path(url, dest_path)
-    fetch_request = requests.get(url, stream=True, headers=USER_AGENT)
+    fetch_request = requests.get(url, stream=True, headers={"User-agent": USER_AGENT})
     total_size = int(fetch_request.headers["content-length"])
     block_size = 1024 * 512
     logger.info("Downloading %s to %s", url, dest_path)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
@@ -9,6 +9,8 @@ from botocore import UNSIGNED
 from botocore.client import Config
 from tqdm import tqdm
 
+from cryoet_data_portal._constants import USER_AGENT
+
 logger = logging.getLogger("cryoet-data-portal")
 
 
@@ -37,7 +39,7 @@ def download_https(
     with_progress: bool = True,
 ):
     dest_path = get_destination_path(url, dest_path)
-    fetch_request = requests.get(url, stream=True)
+    fetch_request = requests.get(url, stream=True, headers=USER_AGENT)
     total_size = int(fetch_request.headers["content-length"])
     block_size = 1024 * 512
     logger.info("Downloading %s to %s", url, dest_path)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
@@ -22,10 +22,13 @@ def get_anon_s3_client():
         return boto3.client(
             "s3",
             endpoint_url=boto_url,
-            config=Config(signature_version=signature_version),
+            config=Config(signature_version=signature_version, user_agent=USER_AGENT),
         )
 
-    return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+    return boto3.client(
+        "s3",
+        config=Config(signature_version=UNSIGNED, user_agent=USER_AGENT),
+    )
 
 
 def parse_s3_url(url: str) -> (str, str):

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_version.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_version.py
@@ -1,0 +1,11 @@
+try:
+    from importlib import metadata
+except ImportError:
+    # for python <=3.7
+    import importlib_metadata as metadata  # type: ignore[no-redef]
+
+try:
+    version = metadata.version("cryoet_data_portal")
+except metadata.PackageNotFoundError:
+    # package is not installed
+    version = "0.0.0-unknown"


### PR DESCRIPTION
# Reason
- To make identifying the user agent who made a request to s3 or the portal backend easier to identify.
- #522 

# Changes
- Move __version__ to _version.py so it can be used in USER_AGENT. 
- Add _constants.py to store the USER_AGENT use in boto3 and http requests
- Add python version, and cryoet-data-portal client version to USER_AGENT.