### PR TITLE
fix: avoid double-encoding spaces in breadcrumb url

### DIFF
--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -12,9 +12,7 @@ import { cns } from 'app/utils/cns'
 
 function encodeParams(params: [string, string | null][]): string {
   const searchParams = new URLSearchParams(
-    (params.filter((kv) => isString(kv[1])) as string[][]).map((kv) =>
-      kv.map(encodeURIComponent),
-    ),
+    params.filter((kv) => isString(kv[1])) as string[][],
   )
 
   return searchParams.toString()


### PR DESCRIPTION
Resolves #814 

~This manually unencodes the space character and replaces `%20` with `+`.  It uses `encodeURIComponent`, but no longer uses the `URLSearchParams` object.  This was necessary to avoid re-encoding the `+` character.  It works, but the approach seems a bit hacky.~

Now just removing the encoding and it works.

![Jul-30-2024 11-16-16](https://github.com/user-attachments/assets/615ede11-8dc2-418a-a32c-685288e4f180)
