### PR TITLE
ci: update frontend release pr filter

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -33,7 +33,7 @@ jobs:
             const { owner, repo } = context.repo
             const { data: searchResult } = await github.rest.search.issuesAndPullRequests(
               {
-                q: `repo:${owner}/${repo} is:pr label:"autorelease: pending"`,
+                q: `repo:${owner}/${repo} is:pr is:open label:"autorelease: pending" "chore(main): release web"`,
                 per_page: 1,
               }
             )


### PR DESCRIPTION
Fixes issue with frontend release workflow using the wrong PR for the release process. Now that we're starting to use release-please for the frontend client, we'll need more filters to target only the frontend release PRs 

## Before

<img width="789" alt="image" src="https://github.com/user-attachments/assets/c00877fc-eab6-404e-a12f-eb045422e93d">

## After

<img width="876" alt="image" src="https://github.com/user-attachments/assets/6afbfcae-80fd-445d-bcd5-f3f26672bcc0">
