### PR TITLE
feat: Enable pagination of Annotations table with temporary hacky query

### DIFF
--- a/frontend/packages/data-portal/app/context/DownloadModal.context.ts
+++ b/frontend/packages/data-portal/app/context/DownloadModal.context.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react'
 
 import { GetRunByIdQuery } from 'app/__generated__/graphql'
-import { Annotation } from 'app/state/annotation'
+import { BaseAnnotation } from 'app/state/annotation'
 
 export type DownloadModalType = 'dataset' | 'runs' | 'annotation'
 
@@ -9,7 +9,7 @@ export type TomogramResolution =
   GetRunByIdQuery['runs'][number]['tomogram_stats'][number]['tomogram_resolutions'][number]
 
 export interface DownloadModalContextValue {
-  activeAnnotation?: Annotation | null
+  activeAnnotation?: BaseAnnotation | null
   activeTomogramResolution?: TomogramResolution | null
   allTomogramProcessing?: string[]
   allTomogramResolutions?: TomogramResolution[]

--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -131,69 +131,6 @@ const GET_RUN_BY_ID_QUERY = gql(`
         }
       }
 
-      annotation_table: tomogram_voxel_spacings {
-        annotations(
-          limit: $limit,
-          offset: $annotationsOffset,
-          where: {
-            _and: $filter
-          },
-          order_by: [
-            { ground_truth_status: desc }
-            { deposition_date: desc }
-            { id: desc }
-          ],
-        ) {
-          annotation_method
-          annotation_publication
-          annotation_software
-          confidence_precision
-          confidence_recall
-          deposition_date
-          ground_truth_status
-          ground_truth_used
-          id
-          is_curator_recommended
-          last_modified_date
-          method_type
-          object_count
-          object_description
-          object_id
-          object_name
-          object_state
-          release_date
-
-          files(
-            where: {
-              _and: $fileFilter
-            }
-          ) {
-            format
-            https_path
-            s3_path
-            shape_type
-          }
-
-          authors(order_by: { author_list_order: asc }) {
-            primary_author_status
-            corresponding_author_status
-            name
-            email
-            orcid
-          }
-
-          author_affiliations: authors(distinct_on: affiliation_name) {
-            affiliation_name
-          }
-
-          authors_aggregate {
-            aggregate {
-              count
-            }
-          }
-        }
-      }
-
       tomogram_stats: tomogram_voxel_spacings {
         annotations {
           object_name
@@ -238,6 +175,80 @@ const GET_RUN_BY_ID_QUERY = gql(`
           }
 
           count
+        }
+      }
+    }
+
+    annotation_files(
+      where: {
+        annotation: {
+          tomogram_voxel_spacing: {
+            run_id: {
+              _eq: $id
+            }
+          }
+          _and: $filter
+        }
+        _and: $fileFilter
+      }
+      order_by: [
+        {
+          annotation: {
+            ground_truth_status: desc
+          }
+        },
+        {
+          annotation: {
+            deposition_date: desc
+          }
+        },
+        annotation_id: desc
+      ]
+      distinct_on: [annotation_id, shape_type]
+      limit: $limit
+      offset: $annotationsOffset
+    ) {
+      format
+      https_path
+      s3_path
+      shape_type
+
+      annotation {
+        annotation_method
+        annotation_publication
+        annotation_software
+        confidence_precision
+        confidence_recall
+        deposition_date
+        ground_truth_status
+        ground_truth_used
+        id
+        is_curator_recommended
+        last_modified_date
+        method_type
+        object_count
+        object_description
+        object_id
+        object_name
+        object_state
+        release_date
+
+        authors(order_by: { author_list_order: asc }) {
+          primary_author_status
+          corresponding_author_status
+          name
+          email
+          orcid
+        }
+
+        author_affiliations: authors(distinct_on: affiliation_name) {
+          affiliation_name
+        }
+
+        authors_aggregate {
+          aggregate {
+            count
+          }
         }
       }
     }

--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -179,10 +179,11 @@ const GET_RUN_BY_ID_QUERY = gql(`
       }
     }
 
+    # Annotations table:
     annotation_files(
       where: {
         format: {
-          _neq: "zarr"
+          _neq: "zarr" # TODO: Remove hack, migrate to new annotation + shape object.
         }
         annotation: {
           tomogram_voxel_spacing: {
@@ -262,6 +263,7 @@ const GET_RUN_BY_ID_QUERY = gql(`
       }
     }
 
+    # Annotation counts:
     annotation_files_aggregate_for_total: annotation_files_aggregate(
       where: {
         annotation: {
@@ -278,7 +280,6 @@ const GET_RUN_BY_ID_QUERY = gql(`
         count
       }
     }
-
     annotation_files_aggregate_for_filtered: annotation_files_aggregate(
       where: {
         annotation: {
@@ -297,7 +298,6 @@ const GET_RUN_BY_ID_QUERY = gql(`
         count
       }
     }
-
     annotation_files_aggregate_for_ground_truth: annotation_files_aggregate(
       where: {
         annotation: {
@@ -319,7 +319,6 @@ const GET_RUN_BY_ID_QUERY = gql(`
         count
       }
     }
-
     annotation_files_aggregate_for_other: annotation_files_aggregate(
       where: {
         annotation: {

--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -202,16 +202,16 @@ const GET_RUN_BY_ID_QUERY = gql(`
             deposition_date: desc
           }
         },
-        annotation_id: desc
+        {
+          annotation_id: desc
+        }
       ]
       distinct_on: [annotation_id, shape_type]
       limit: $limit
       offset: $annotationsOffset
     ) {
-      format
-      https_path
-      s3_path
       shape_type
+      format
 
       annotation {
         annotation_method
@@ -232,6 +232,13 @@ const GET_RUN_BY_ID_QUERY = gql(`
         object_name
         object_state
         release_date
+
+        files(where: { _and: $fileFilter }) {
+          shape_type
+          format
+          https_path
+          s3_path
+        }
 
         authors(order_by: { author_list_order: asc }) {
           primary_author_status
@@ -360,13 +367,8 @@ function getFilter(filterState: FilterState): Annotations_Bool_Exp[] {
     })
   }
 
-  const {
-    objectNames,
-    objectShapeTypes,
-    annotationSoftwares,
-    methodTypes,
-    goId,
-  } = filterState.annotation
+  const { objectNames, annotationSoftwares, methodTypes, goId } =
+    filterState.annotation
 
   if (objectNames.length > 0) {
     filters.push({
@@ -380,16 +382,6 @@ function getFilter(filterState: FilterState): Annotations_Bool_Exp[] {
     filters.push({
       object_id: {
         _ilike: `%${goId.replace(':', '_')}`,
-      },
-    })
-  }
-
-  if (objectShapeTypes.length > 0) {
-    filters.push({
-      files: {
-        shape_type: {
-          _in: objectShapeTypes,
-        },
       },
     })
   }

--- a/frontend/packages/data-portal/app/graphql/getRunById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunById.server.ts
@@ -181,6 +181,9 @@ const GET_RUN_BY_ID_QUERY = gql(`
 
     annotation_files(
       where: {
+        format: {
+          _neq: "zarr"
+        }
         annotation: {
           tomogram_voxel_spacing: {
             run_id: {
@@ -206,7 +209,6 @@ const GET_RUN_BY_ID_QUERY = gql(`
           annotation_id: desc
         }
       ]
-      distinct_on: [annotation_id, shape_type]
       limit: $limit
       offset: $annotationsOffset
     ) {

--- a/frontend/packages/data-portal/app/hooks/useRunById.ts
+++ b/frontend/packages/data-portal/app/hooks/useRunById.ts
@@ -8,6 +8,8 @@ export function useRunById() {
 
   const run = data.runs[0]
 
+  const annotationFiles = data.annotation_files
+
   const objectNames = useMemo(
     () =>
       Array.from(
@@ -61,6 +63,7 @@ export function useRunById() {
 
   return {
     run,
+    annotationFiles,
     objectNames,
     objectShapeTypes,
     annotationSoftwares,

--- a/frontend/packages/data-portal/app/state/annotation.ts
+++ b/frontend/packages/data-portal/app/state/annotation.ts
@@ -4,14 +4,13 @@ import { useMemo } from 'react'
 import { GetRunByIdQuery } from 'app/__generated__/graphql'
 
 export type BaseAnnotation =
-  GetRunByIdQuery['runs'][number]['annotation_table'][number]['annotations'][number]
+  GetRunByIdQuery['annotation_files'][number]['annotation']
 
-export type AnnotationFile =
-  GetRunByIdQuery['runs'][number]['annotation_table'][number]['annotations'][number]['files'][number]
+export type AnnotationFile = GetRunByIdQuery['annotation_files'][number]
 
-export type Annotation = BaseAnnotation & AnnotationFile
+export type AnnotationRow = BaseAnnotation & Omit<AnnotationFile, 'annotation'>
 
-const activeAnnotationAtom = atom<Annotation | null>(null)
+const activeAnnotationAtom = atom<AnnotationRow | null>(null)
 
 export function useAnnotation() {
   const [activeAnnotation, setActiveAnnotation] = useAtom(activeAnnotationAtom)

--- a/frontend/packages/data-portal/app/utils/annotation.ts
+++ b/frontend/packages/data-portal/app/utils/annotation.ts
@@ -1,6 +1,8 @@
-import { Annotation } from 'app/state/annotation'
+import { AnnotationRow } from 'app/state/annotation'
 
-export function getAnnotationTitle(annotation: Annotation | undefined | null) {
+export function getAnnotationTitle(
+  annotation: AnnotationRow | undefined | null,
+) {
   if (!annotation) {
     return '--'
   }

--- a/frontend/packages/data-portal/e2e/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/filters/utils.ts
@@ -91,10 +91,7 @@ export function getAnnotationTableFilterValidator(
   expectedData: GetRunByIdQuery,
 ) {
   const annotationIds = new Set(
-    expectedData.runs
-      .at(0)
-      ?.annotation_table.at(0)
-      ?.annotations.map((annotation) => annotation.id),
+    expectedData.annotation_files.map((file) => file.annotation.id),
   )
 
   return async (page: Page) => {

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
@@ -77,17 +77,13 @@ export function getAnnotationRowCountFromData({
   singleRunData: GetRunByIdQuery
 }): RowCounterType {
   const rowCounter: RowCounterType = {}
-  singleRunData.runs
-    .at(0)
-    ?.annotation_table.at(0)
-    ?.annotations.reduce((counter, annotation) => {
-      const objectShapeTypes = new Set()
-      for (const file of annotation.files) {
-        objectShapeTypes.add(file.shape_type)
-      }
-      counter[annotation.id] = objectShapeTypes.size
-      return counter
-    }, rowCounter)
+  for (const file of singleRunData.annotation_files) {
+    if (rowCounter[file.annotation.id] === undefined) {
+      rowCounter[file.annotation.id] = 1
+    } else {
+      rowCounter[file.annotation.id]++
+    }
+  }
   return rowCounter
 }
 // #endregion runPage

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
@@ -81,7 +81,7 @@ export function getAnnotationRowCountFromData({
     if (rowCounter[file.annotation.id] === undefined) {
       rowCounter[file.annotation.id] = 1
     } else {
-      rowCounter[file.annotation.id]++
+      rowCounter[file.annotation.id] += 1
     }
   }
   return rowCounter

--- a/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
@@ -211,8 +211,7 @@ export async function getAnnotationTestData(
     annotationsPage: 1,
   })
 
-  const [run] = data.runs
-  const annotation = run.annotation_table[0].annotations[0]
+  const { annotation } = data.annotation_files[0]
 
   return {
     title: `${annotation.id} - ${annotation.object_name}`,

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -75,5 +75,15 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
+
+    // Allow us to use the above naming pattern for destructuring unused variables.
+    '@typescript-eslint/naming-convention': [
+      'error', 
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow'
+      }
+    ]
   },
 }

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -82,8 +82,8 @@ module.exports = {
       {
         selector: 'variable',
         format: ['camelCase', 'UPPER_CASE'],
-        leadingUnderscore: 'allow'
-      }
-    ]
+        leadingUnderscore: 'allow',
+      },
+    ],
   },
 }

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -81,7 +81,7 @@ module.exports = {
       'error',
       {
         selector: 'variable',
-        format: ['camelCase', 'UPPER_CASE'],
+        format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
         leadingUnderscore: 'allow',
       },
     ],

--- a/frontend/packages/eslint-config/typescript.cjs
+++ b/frontend/packages/eslint-config/typescript.cjs
@@ -78,7 +78,7 @@ module.exports = {
 
     // Allow us to use the above naming pattern for destructuring unused variables.
     '@typescript-eslint/naming-convention': [
-      'error', 
+      'error',
       {
         selector: 'variable',
         format: ['camelCase', 'UPPER_CASE'],


### PR DESCRIPTION
#581 

This changes the Annotations table GQL to query annotation_files at the top level instead of annotations.

Because `distinct_on` was not able to be used to generate distinct `annotation` and `shape_type` pairs (see comments in issue), this instead ignores .zarr files for the time being to make each `annotation_file`'s `shape_type` within an `annotation` unique.