### PR TITLE
chore: Add e2e test for errors on Neuroglancer site

### DIFF
--- a/.github/workflows/frontend-pr-e2e-tests.yml
+++ b/.github/workflows/frontend-pr-e2e-tests.yml
@@ -17,4 +17,4 @@ jobs:
       environment: local
       # Only test on chromium to keep PR E2E tests fast. Staging E2E tests will
       # test on all browsers.
-      browsers: '["chromium"]'
+      browsers: '["firefox", "webkit"]'

--- a/.github/workflows/frontend-pr-e2e-tests.yml
+++ b/.github/workflows/frontend-pr-e2e-tests.yml
@@ -17,4 +17,4 @@ jobs:
       environment: local
       # Only test on chromium to keep PR E2E tests fast. Staging E2E tests will
       # test on all browsers.
-      browsers: '["firefox", "webkit"]'
+      browsers: '["chromium"]'

--- a/frontend/packages/data-portal/e2e/pageObjects/neuroglancerPage.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/neuroglancerPage.ts
@@ -2,6 +2,7 @@ import { Locator } from '@playwright/test'
 
 import { BasePage } from './basePage'
 
+/** neuroglancer-demo.appspot.com */
 export class NeuroglancerPage extends BasePage {
   findViewer(): Locator {
     return this.page.locator('.neuroglancer-viewer')

--- a/frontend/packages/data-portal/e2e/pageObjects/neuroglancerPage.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/neuroglancerPage.ts
@@ -1,0 +1,13 @@
+import { Locator } from '@playwright/test'
+
+import { BasePage } from './basePage'
+
+export class NeuroglancerPage extends BasePage {
+  findViewer(): Locator {
+    return this.page.locator('.neuroglancer-viewer')
+  }
+
+  findErrorText(): Locator {
+    return this.page.getByText('Error')
+  }
+}

--- a/frontend/packages/data-portal/e2e/pageObjects/singleRunPage.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/singleRunPage.ts
@@ -1,0 +1,14 @@
+import { Locator } from '@playwright/test'
+import { SINGLE_RUN_URL } from 'e2e/constants'
+
+import { BasePage } from './basePage'
+
+export class SingleRunPage extends BasePage {
+  async goToPage() {
+    await this.goTo(SINGLE_RUN_URL)
+  }
+
+  getPrimaryViewTomogramButton(): Locator {
+    return this.page.locator('a:has-text("View Tomogram")')
+  }
+}

--- a/frontend/packages/data-portal/e2e/pageObjects/singleRunPage.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/singleRunPage.ts
@@ -3,6 +3,7 @@ import { SINGLE_RUN_URL } from 'e2e/constants'
 
 import { BasePage } from './basePage'
 
+/** /runs/$id */
 export class SingleRunPage extends BasePage {
   async goToPage() {
     await this.goTo(SINGLE_RUN_URL)

--- a/frontend/packages/data-portal/e2e/singleRun.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRun.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+
+import { NeuroglancerPage } from './pageObjects/neuroglancerPage'
+import { SingleRunPage } from './pageObjects/singleRunPage'
+
+test.describe('Single run page: ', () => {
+  let page: SingleRunPage
+  let neuroglancerPage: NeuroglancerPage
+  test.beforeEach(async ({ page: playwrightPage }) => {
+    page = new SingleRunPage(playwrightPage)
+    neuroglancerPage = new NeuroglancerPage(playwrightPage)
+    await page.goToPage()
+  })
+
+  /** This test ensures that the following test is not a false negative. */
+  test('Invalid Neuroglancer URL results in error on Neuroglancer page', async () => {
+    await page.goTo(
+      (await page.getPrimaryViewTomogramButton().getAttribute('href'))!.replace(
+        '#!',
+        "#!'",
+      ),
+    )
+
+    await expect(neuroglancerPage.findViewer()).toBeVisible()
+    await expect(neuroglancerPage.findErrorText()).toBeVisible()
+  })
+
+  test('Neuroglancer URL does not result in error on Neuroglancer page', async () => {
+    await page.goTo(
+      (await page.getPrimaryViewTomogramButton().getAttribute('href'))!,
+    )
+
+    await expect(neuroglancerPage.findViewer()).toBeVisible()
+    await expect(neuroglancerPage.findErrorText()).toHaveCount(0)
+  })
+})

--- a/frontend/packages/data-portal/e2e/singleRun.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRun.test.ts
@@ -12,7 +12,7 @@ test.describe('Single run page: ', () => {
     await page.goToPage()
   })
 
-  /** This test ensures that the following test is not a false negative. */
+  /** This test ensures that the test after it is not a false negative. */
   test('Invalid Neuroglancer URL results in error on Neuroglancer page', async () => {
     await page.goTo(
       (await page.getPrimaryViewTomogramButton().getAttribute('href'))!.replace(
@@ -22,7 +22,7 @@ test.describe('Single run page: ', () => {
     )
 
     await expect(neuroglancerPage.findViewer()).toBeVisible()
-    await expect(neuroglancerPage.findErrorText()).toBeVisible()
+    await expect(neuroglancerPage.findErrorText()).toHaveCount(1)
   })
 
   test('Neuroglancer URL does not result in error on Neuroglancer page', async () => {

--- a/frontend/packages/data-portal/e2e/singleRun.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRun.test.ts
@@ -14,13 +14,6 @@ test.describe('Single run page: ', () => {
 
   /** This test ensures that the test after it is not a false negative. */
   test('Invalid Neuroglancer URL results in error on Neuroglancer page', async () => {
-    // const url = (await page
-    //   .getPrimaryViewTomogramButton()
-    //   .getAttribute('href'))!.replace('#!', "#!'")
-    // await page.page.evaluate(() => {
-    //   document.location.href = url
-    // })
-    await page.page.goto('http://youtube.com')
     await page.goTo(
       (await page.getPrimaryViewTomogramButton().getAttribute('href'))!.replace(
         '#!',

--- a/frontend/packages/data-portal/e2e/singleRun.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRun.test.ts
@@ -20,7 +20,7 @@ test.describe('Single run page: ', () => {
     // await page.page.evaluate(() => {
     //   document.location.href = url
     // })
-    await page.page.goto('http://google.com')
+    await page.page.goto('http://youtube.com')
     await page.goTo(
       (await page.getPrimaryViewTomogramButton().getAttribute('href'))!.replace(
         '#!',

--- a/frontend/packages/data-portal/e2e/singleRun.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRun.test.ts
@@ -14,6 +14,13 @@ test.describe('Single run page: ', () => {
 
   /** This test ensures that the test after it is not a false negative. */
   test('Invalid Neuroglancer URL results in error on Neuroglancer page', async () => {
+    // const url = (await page
+    //   .getPrimaryViewTomogramButton()
+    //   .getAttribute('href'))!.replace('#!', "#!'")
+    // await page.page.evaluate(() => {
+    //   document.location.href = url
+    // })
+    await page.page.goto('http://google.com')
     await page.goTo(
       (await page.getPrimaryViewTomogramButton().getAttribute('href'))!.replace(
         '#!',

--- a/frontend/packages/data-portal/playwright.config.ts
+++ b/frontend/packages/data-portal/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
-          args: ['--ignore-gpu-blocklist', '--use-gl=angle'],
+          args: ['--use-gl=angle'],
         },
 
         contextOptions: {

--- a/frontend/packages/data-portal/playwright.config.ts
+++ b/frontend/packages/data-portal/playwright.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--use-gl=egl', '--ignore-gpu-blocklist', '--use-gl=angle'],
+        },
 
         contextOptions: {
           permissions: ['clipboard-read', 'clipboard-write'],

--- a/frontend/packages/data-portal/playwright.config.ts
+++ b/frontend/packages/data-portal/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
-          args: ['--use-gl=egl', '--ignore-gpu-blocklist', '--use-gl=angle'],
+          args: ['--ignore-gpu-blocklist', '--use-gl=angle'],
         },
 
         contextOptions: {

--- a/frontend/packages/data-portal/playwright.config.ts
+++ b/frontend/packages/data-portal/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         launchOptions: {
-          args: ['--use-gl=angle'],
+          args: ['--ignore-gpu-blocklist', '--use-gl=angle'],
         },
 
         contextOptions: {


### PR DESCRIPTION
#1025

Had to add some startup flags to chromium so that WebGL is enabled (and the Neuroglancer site actually loads).

Tried with firefox and webkit as well and both worked without any extra flags.