### PR TITLE
fix: wrap collapsible lists in a div

### DIFF
--- a/frontend/packages/data-portal/app/components/CollapsibleList.tsx
+++ b/frontend/packages/data-portal/app/components/CollapsibleList.tsx
@@ -40,7 +40,7 @@ export function CollapsibleList({
     collapsible && collapsed ? collapseAfter - 1 : (entries ?? []).length - 1
 
   return entries ? (
-    <>
+    <div>
       <ul
         className={cns(
           'flex',
@@ -100,7 +100,7 @@ export function CollapsibleList({
           </button>
         </div>
       )}
-    </>
+    </div>
   ) : (
     <p className="text-sds-body-xxs leading-sds-body-xxs text-sds-gray-600">
       {t('notSubmitted')}


### PR DESCRIPTION
fix alignment of show more/less button when collapsible list is in a grid

#### Before

<img width="612" alt="Screenshot 2024-08-19 at 12 11 04 PM" src="https://github.com/user-attachments/assets/b533e89e-6261-4dce-8921-40843ad7dcb6">

#### After

<img width="643" alt="Screenshot 2024-08-19 at 12 11 29 PM" src="https://github.com/user-attachments/assets/fe2bf70d-f83d-46e3-843d-8da557c8d27c">
