### PR TITLE
fix: wait for graphql to be healthy in client tests

### DIFF
--- a/client/python/cryoet_data_portal/Makefile
+++ b/client/python/cryoet_data_portal/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test-infra
 test-infra:
-	cd tests && docker compose up -d
+	cd tests && docker compose up -d --wait --wait-timeout 300
 	cd ./tests/test_infra/; ./seed_moto.sh
 
 .PHONY: coverage

--- a/client/python/cryoet_data_portal/tests/docker-compose.yml
+++ b/client/python/cryoet_data_portal/tests/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+    healthcheck:
+      test: timeout 1s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
The existing `test-infra` make target calls `docker compose up` to set up the various services needed for the Python client tests to run successfully. This change forces `docker compose up` to wait until the `graphql-engine` service is healthy before it exits. I borrowed the healthcheck test from another similar docker compose service in this and the corresponding backend repo.

I added a wait timeout so that our runners cannot hang indefinitely on this step. The [`docker compose up` docs](https://docs.docker.com/reference/cli/docker/compose/up/) are not totally clear, but I assume `--wait-timeout` is specified in seconds because `--timeout` is specified as such. I chose 300 seconds because this step takes about 30 seconds on my fairly speedy laptop, so multiplying by 10 for a random GitHub Actions runner seems reasonable.

As this is a fix for a flakey test, it's hard to be confident that this is a definitive fix. However, I can consistently reproduce the flakey error by running `make test-infra && make test` after stopping the corresponding docker containers. After the changes here, I cannot reproduce the error.

Closes #942 