### PR TITLE
ci: fixes prod e2e tests

### DIFF
--- a/frontend/packages/data-portal/e2e/config.json
+++ b/frontend/packages/data-portal/e2e/config.json
@@ -13,7 +13,7 @@
   "organismName1": "Bacillus subtilis",
   "organismName2": "Bdellovibrio bacteriovorus",
   "organismNameQuery": "bac",
-  "reconstructionMethod": "Weighted back projection",
+  "reconstructionMethod": "SIRT",
   "reconstructionObjectName": "Actin filament",
   "reconstructionSoftware": "IMOD",
   "runId": "258",


### PR DESCRIPTION
The E2E tests for prod are failing because `Weighted back projection` is no longer available as an option in prod. This updates it to an option that is present on prod and staging:

- Prod: https://cryoetdataportal.czscience.com/browse-data/datasets?reconstruction_method=SIRT
- Staging: https://frontend.cryoet.staging.si.czi.technology/browse-data/datasets?reconstruction_method=SIRT

## Demo

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/10496053963

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/29e99090-4e37-449e-aca5-4fab275ac265">
