### PR TITLE
chore: add instructions and commands to manually release the python package.

### DIFF
--- a/client/python/cryoet_data_portal/Makefile
+++ b/client/python/cryoet_data_portal/Makefile
@@ -37,3 +37,10 @@ build:
 	python -m pip install --upgrade pip
 	pip install build twine
 	python -m build
+
+release/testpypi: build
+	python -m twine upload --repository testpypi dist/*
+
+release/pypi: build
+	# Manually release in case CI/CD pipeline is not working in ./.github/workflows/release.yml
+	python -m twine upload dist/*

--- a/client/python/cryoet_data_portal/release_process.md
+++ b/client/python/cryoet_data_portal/release_process.md
@@ -8,3 +8,12 @@ The python client can be build locally by running the following:
 ```bash
 make build
 ```
+
+# Manual Release Process
+After merging in the release-please PR, if the python package did not release it can be manually release by doing the following:
+1. Setup your environment to upload to pypi by following the instructions [here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#create-an-account)
+2. Pull the latest changes from main
+3Run the following command to release the python client:
+```bash
+make release/pypi
+```

--- a/client/python/cryoet_data_portal/release_process.md
+++ b/client/python/cryoet_data_portal/release_process.md
@@ -13,7 +13,7 @@ make build
 After merging in the release-please PR, if the python package did not release it can be manually release by doing the following:
 1. Setup your environment to upload to pypi by following the instructions [here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#create-an-account)
 2. Pull the latest changes from main
-3Run the following command to release the python client:
+3. Run the following command to release the python client:
 ```bash
 make release/pypi
 ```


### PR DESCRIPTION
adding manual steps to release due to https://github.com/chanzuckerberg/cryoet-data-portal/issues/1072