### PR TITLE
fix: ID detection for annotation object id link 

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/AnnotationObjectTable/components/ObjectIdLink/ObjectIdLink.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationObjectTable/components/ObjectIdLink/ObjectIdLink.tsx
@@ -1,16 +1,16 @@
 import { Link } from 'app/components/Link'
 import {
   GO,
-  GO_PATTERN,
+  GO_PREFIX,
   UNIPROTKB,
-  UNIPROTKB_PATTERN,
+  UNIPROTKB_PREFIX,
 } from 'app/constants/annotationObjectIdLinks'
 
 export function ObjectIdLink({ id }: { id: string }) {
   let link
-  if (id.match(GO_PATTERN)) {
+  if (id.startsWith(GO_PREFIX)) {
     link = `${GO}${id}`
-  } else if (id.match(UNIPROTKB_PATTERN)) {
+  } else if (id.startsWith(UNIPROTKB_PREFIX)) {
     link = `${UNIPROTKB}${id.replaceAll('UniProtKB:', '')}`
   }
   // don't link if no patterns match

--- a/frontend/packages/data-portal/app/constants/annotationObjectIdLinks.ts
+++ b/frontend/packages/data-portal/app/constants/annotationObjectIdLinks.ts
@@ -1,6 +1,5 @@
 export const GO = 'https://amigo.geneontology.org/amigo/term/'
 export const UNIPROTKB = 'https://www.uniprot.org/uniprotkb/'
 
-export const GO_PATTERN = /GO:[0-9]{7}/
-export const UNIPROTKB_PATTERN =
-  /UniProtKB:[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}/
+export const GO_PREFIX = 'GO:'
+export const UNIPROTKB_PREFIX = 'UniProtKB:'


### PR DESCRIPTION
A patch to a recently merged PR (#1068) Some small changes were not properly committed and I missed that. 