### PR TITLE
feat: Make main photo HTML and CSS consistent between run and dataset pages

### DIFF
--- a/frontend/packages/data-portal/app/components/Dataset/DatasetHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/DatasetHeader.tsx
@@ -2,7 +2,6 @@ import { Button, Icon } from '@czi-sds/components'
 
 import { Breadcrumbs } from 'app/components/Breadcrumbs'
 import { DatasetOverview } from 'app/components/Dataset/DatasetOverview'
-import { KeyPhoto } from 'app/components/KeyPhoto'
 import { PageHeader } from 'app/components/PageHeader'
 import { useDatasetById } from 'app/hooks/useDatasetById'
 import { useDownloadModalQueryParamState } from 'app/hooks/useDownloadModalQueryParamState'
@@ -11,6 +10,8 @@ import {
   MetadataDrawerId,
   useMetadataDrawer,
 } from 'app/hooks/useMetadataDrawer'
+
+import { HeaderKeyPhoto } from '../HeaderKeyPhoto'
 
 export function DatasetHeader() {
   const { dataset } = useDatasetById()
@@ -42,13 +43,11 @@ export function DatasetHeader() {
       releaseDate={dataset.release_date}
       title={dataset.title}
       renderHeader={({ moreInfo }) => (
-        <div className="flex flex-row justify-between gap-sds-xxl p-sds-xl">
-          <div className="max-w-[465px] max-h-[330px]">
-            <KeyPhoto
-              title={dataset.title}
-              src={dataset.key_photo_url ?? undefined}
-            />
-          </div>
+        <div className="flex flex-auto gap-sds-xxl p-sds-xl">
+          <HeaderKeyPhoto
+            title={dataset.title}
+            url={dataset.key_photo_url ?? undefined}
+          />
 
           <div className="flex flex-col gap-sds-xl flex-1 min-w-[300px]">
             <DatasetOverview />

--- a/frontend/packages/data-portal/app/components/Dataset/DatasetHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/DatasetHeader.tsx
@@ -43,7 +43,7 @@ export function DatasetHeader() {
       releaseDate={dataset.release_date}
       title={dataset.title}
       renderHeader={({ moreInfo }) => (
-        <div className="flex flex-auto gap-sds-xxl p-sds-xl">
+        <div className="flex flex-row justify-between gap-sds-xxl p-sds-xl">
           <HeaderKeyPhoto
             title={dataset.title}
             url={dataset.key_photo_url ?? undefined}

--- a/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
+++ b/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
@@ -1,0 +1,21 @@
+import { KeyPhoto } from './KeyPhoto'
+import { Link } from './Link'
+
+export interface HeaderKeyPhotoProps {
+  title: string
+  url?: string
+}
+
+export function HeaderKeyPhoto({ url, title }: HeaderKeyPhotoProps) {
+  return (
+    <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m flex-shrink-0 flex items-center">
+      {url !== undefined ? (
+        <Link to={url}>
+          <KeyPhoto title={title} src={url} />
+        </Link>
+      ) : (
+        <KeyPhoto title={title} />
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/data-portal/app/components/PageHeader.tsx
+++ b/frontend/packages/data-portal/app/components/PageHeader.tsx
@@ -28,7 +28,7 @@ export function PageHeader({
 
   return (
     <div className="flex flex-auto justify-center grow-0">
-      <header className="flex flex-col items-center w-full min-h-[48x]">
+      <header className="flex flex-col items-center w-full min-h-[48px]">
         <div className="flex flex-col justify-start w-full pb-sds-xl">
           <div
             className={cns(

--- a/frontend/packages/data-portal/app/components/PageHeader.tsx
+++ b/frontend/packages/data-portal/app/components/PageHeader.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
   return (
     <div className="flex flex-auto justify-center grow-0">
       <header className="flex flex-col items-center w-full min-h-[48px]">
-        <div className="flex flex-col justify-start w-full pb-sds-xl">
+        <div className="flex flex-col justify-start w-full">
           <div
             className={cns(
               'flex justify-center',

--- a/frontend/packages/data-portal/app/components/PageHeader.tsx
+++ b/frontend/packages/data-portal/app/components/PageHeader.tsx
@@ -28,7 +28,7 @@ export function PageHeader({
 
   return (
     <div className="flex flex-auto justify-center grow-0">
-      <header className="flex flex-col items-center w-full min-h-[48px]">
+      <header className="flex flex-col items-center w-full min-h-[48 x]">
         <div className="flex flex-col justify-start w-full pb-sds-xl">
           <div
             className={cns(

--- a/frontend/packages/data-portal/app/components/PageHeader.tsx
+++ b/frontend/packages/data-portal/app/components/PageHeader.tsx
@@ -28,7 +28,7 @@ export function PageHeader({
 
   return (
     <div className="flex flex-auto justify-center grow-0">
-      <header className="flex flex-col items-center w-full min-h-[48 x]">
+      <header className="flex flex-col items-center w-full min-h-[48x]">
         <div className="flex flex-col justify-start w-full pb-sds-xl">
           <div
             className={cns(

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -3,8 +3,6 @@ import { Button, Icon } from '@czi-sds/components'
 import { Breadcrumbs } from 'app/components/Breadcrumbs'
 import { I18n } from 'app/components/I18n'
 import { InlineMetadata } from 'app/components/InlineMetadata'
-import { KeyPhoto } from 'app/components/KeyPhoto'
-import { Link } from 'app/components/Link'
 import { PageHeader } from 'app/components/PageHeader'
 import { PageHeaderSubtitle } from 'app/components/PageHeaderSubtitle'
 import { MetadataTable } from 'app/components/Table'
@@ -23,7 +21,7 @@ import { useFeatureFlag } from 'app/utils/featureFlags'
 import { getTiltRangeLabel } from 'app/utils/tiltSeries'
 
 import { CollapsibleList } from '../CollapsibleList'
-import { cns } from 'app/utils/cns'
+import { HeaderKeyPhoto } from '../HeaderKeyPhoto'
 
 interface FileSummaryData {
   key: string
@@ -59,7 +57,7 @@ export function RunHeader() {
   const tiltSeries = run.tiltseries[0]
 
   const tomogram = run.tomogram_voxel_spacings.at(0)?.tomograms.at(0)
-  const keyPhotoURL = tomogram?.key_photo_url
+  const keyPhotoURL = tomogram?.key_photo_url ?? undefined
   const neuroglancerConfig = tomogram?.neuroglancer_config
 
   const { openTomogramDownloadModal } = useDownloadModalQueryParamState()
@@ -114,21 +112,8 @@ export function RunHeader() {
       onMoreInfoClick={() => toggleDrawer(MetadataDrawerId.Run)}
       title={run.name}
       renderHeader={({ moreInfo }) => (
-        <div
-          className={cns(
-            'flex flex-auto gap-sds-xxl p-sds-xl',
-            multipleTomogramsEnabled && 'pb-0',
-          )}
-        >
-          <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m flex-shrink-0 flex items-center">
-            {keyPhotoURL ? (
-              <Link to={keyPhotoURL}>
-                <KeyPhoto title={run.name} src={keyPhotoURL} />
-              </Link>
-            ) : (
-              <KeyPhoto title={run.name} />
-            )}
-          </div>
+        <div className="flex flex-auto gap-sds-xxl p-sds-xl">
+          <HeaderKeyPhoto title={run.name} url={keyPhotoURL} />
 
           <div className="flex flex-col gap-sds-xl flex-auto pt-sds-l">
             <PageHeaderSubtitle className="mt-sds-m">

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -23,6 +23,7 @@ import { useFeatureFlag } from 'app/utils/featureFlags'
 import { getTiltRangeLabel } from 'app/utils/tiltSeries'
 
 import { CollapsibleList } from '../CollapsibleList'
+import { cns } from 'app/utils/cns'
 
 interface FileSummaryData {
   key: string
@@ -113,7 +114,12 @@ export function RunHeader() {
       onMoreInfoClick={() => toggleDrawer(MetadataDrawerId.Run)}
       title={run.name}
       renderHeader={({ moreInfo }) => (
-        <div className="flex flex-auto gap-sds-xxl p-sds-xl">
+        <div
+          className={cns(
+            'flex flex-auto gap-sds-xxl p-sds-xl',
+            multipleTomogramsEnabled && 'pb-0',
+          )}
+        >
           <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m flex-shrink-0 flex items-center">
             {keyPhotoURL ? (
               <Link to={keyPhotoURL}>


### PR DESCRIPTION
#1047

 - Fixes extra padding in header.
 - Adds ability to click dataset image (like run image).