### PR TITLE
ci: skip e2e if feature disabled

### DIFF
--- a/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
@@ -11,7 +11,7 @@ import { QueryParams } from 'app/constants/query'
 
 import { getApolloClient } from './apollo'
 import { BROWSE_DATASETS_URL, E2E_CONFIG, translations } from './constants'
-import { skipIfFeatureIsDisabled } from './utils'
+import { onlyRunIfEnabled } from './utils'
 
 test.describe('Browse datasets page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -1129,7 +1129,7 @@ test.describe('Browse datasets page filters', () => {
   })
 
   test.describe('Deposition IDs filter group', () => {
-    skipIfFeatureIsDisabled('depositions')
+    onlyRunIfEnabled('depositions')
 
     test.describe('Deposition ID filter', () => {
       test('should filter when selecting', async () => {

--- a/frontend/packages/data-portal/e2e/utils.ts
+++ b/frontend/packages/data-portal/e2e/utils.ts
@@ -2,7 +2,7 @@ import { test } from '@playwright/test'
 
 import { FeatureFlagKey, getFeatureFlag } from 'app/utils/featureFlags'
 
-export function skipIfFeatureIsDisabled(key: FeatureFlagKey) {
+export function onlyRunIfEnabled(key: FeatureFlagKey) {
   const isEnabled = getFeatureFlag({
     key,
     env: process.env.ENV,


### PR DESCRIPTION
Adds a new util function to skip e2e tests if a certain feature is not enabled. This should also fix the prod E2Es that have been failing for a bit