### PR TITLE
ci: add missing skip e2e

### DIFF
--- a/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
@@ -8,6 +8,7 @@ import { QueryParams } from 'app/constants/query'
 
 import { getApolloClient } from './apollo'
 import { E2E_CONFIG, SINGLE_DATASET_URL, translations } from './constants'
+import { onlyRunIfEnabled } from './utils'
 
 test.describe('Single dataset page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -108,6 +109,8 @@ test.describe('Single dataset page filters', () => {
     })
   })
   test.describe('Deposition ID filter', () => {
+    onlyRunIfEnabled('depositions')
+
     test('should filter when selecting', async () => {
       await filtersPage.goTo(SINGLE_DATASET_URL)
 

--- a/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
@@ -8,6 +8,7 @@ import { QueryParams } from 'app/constants/query'
 
 import { getApolloClient } from './apollo'
 import { E2E_CONFIG, SINGLE_RUN_URL, translations } from './constants'
+import { onlyRunIfEnabled } from './utils'
 
 test.describe('Single run page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -213,6 +214,8 @@ test.describe('Single run page filters', () => {
     })
   })
   test.describe('Deposition ID filter', () => {
+    onlyRunIfEnabled('depositions')
+
     test('should filter when selecting', async () => {
       await filtersPage.goTo(SINGLE_RUN_URL)
 


### PR DESCRIPTION
Added e2e skips in a few places where the deposition ID filter tests are located