### PR TITLE
fix: header key photo sizing

### DIFF
--- a/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
+++ b/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
@@ -8,7 +8,7 @@ export interface HeaderKeyPhotoProps {
 
 export function HeaderKeyPhoto({ url, title }: HeaderKeyPhotoProps) {
   return (
-    <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m flex-shrink-0 flex items-center">
+    <div className="max-w-[465px] max-h-[330px] grow">
       {url !== undefined ? (
         <Link to={url}>
           <KeyPhoto title={title} src={url} />

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -115,7 +115,7 @@ export function RunHeader() {
         <div className="flex flex-auto gap-sds-xxl p-sds-xl">
           <HeaderKeyPhoto title={run.name} url={keyPhotoURL} />
 
-          <div className="flex flex-col gap-sds-xl flex-auto pt-sds-l">
+          <div className="flex flex-col gap-sds-xl flex-1 pt-sds-l">
             <PageHeaderSubtitle className="mt-sds-m">
               {t('runOverview')}
             </PageHeaderSubtitle>


### PR DESCRIPTION
fix misc sizing issues for header key photos across various pages

### Before

https://github.com/user-attachments/assets/cc7ce779-c1f8-45c9-842c-0182f4834a74

### After

https://github.com/user-attachments/assets/ba9b89a7-81f1-4282-980a-f8ec6a10f6c3

