### PR TITLE
chore: Leave comments about not refactoring pagination tests

### DIFF
--- a/frontend/packages/data-portal/e2e/pagination.test.ts
+++ b/frontend/packages/data-portal/e2e/pagination.test.ts
@@ -1,3 +1,8 @@
+/*
+ * NOTE: This file does not use the preferred page object pattern.
+ * This is because we did not have time to refactor.
+ * Please do not use this file as an example of how to write tests.
+ */
 import { TableValidatorOptions } from 'e2e/pageObjects/filters/types'
 
 import { MAX_PER_PAGE } from 'app/constants/pagination'

--- a/frontend/packages/data-portal/e2e/pagination/testPagination.ts
+++ b/frontend/packages/data-portal/e2e/pagination/testPagination.ts
@@ -1,3 +1,8 @@
+/*
+ * NOTE: This file does not use the preferred page object pattern.
+ * This is because we did not have time to refactor.
+ * Please do not use this file as an example of how to write tests.
+ */
 import { expect, Page, test } from '@playwright/test'
 import { getApolloClient } from 'e2e/apollo'
 import { E2E_CONFIG } from 'e2e/constants'


### PR DESCRIPTION
Relates to #963 

We decided to deprioritize refactoring the pagination tests since we do not anticipate needing updates soon.  This PR adds a comment to the two pagination related test files indicating that future devs should follow the page object model instead.