### PR TITLE
feat: Id prefixes in filters

### DIFF
--- a/frontend/packages/data-portal/app/components/AnnotationFilter/ObjectIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/AnnotationFilter/ObjectIdFilter.tsx
@@ -1,7 +1,7 @@
 import { RegexFilter } from 'app/components/Filters'
 import { QueryParams } from 'app/constants/query'
 import { useI18n } from 'app/hooks/useI18n'
-import { objectIdRegex } from 'app/utils/idPrefixes'
+import { OBJECT_ID_REGEX } from 'app/utils/idPrefixes'
 
 export function ObjectIdFilter() {
   const { t } = useI18n()
@@ -12,7 +12,7 @@ export function ObjectIdFilter() {
       title={t('filterByObjectId')}
       label={t('objectId')}
       queryParam={QueryParams.ObjectId}
-      regex={objectIdRegex}
+      regex={OBJECT_ID_REGEX}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/AnnotationFilter/ObjectIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/AnnotationFilter/ObjectIdFilter.tsx
@@ -1,10 +1,7 @@
 import { RegexFilter } from 'app/components/Filters'
-import {
-  GO_PREFIX,
-  UNIPROTKB_PREFIX,
-} from 'app/constants/annotationObjectIdLinks'
 import { QueryParams } from 'app/constants/query'
 import { useI18n } from 'app/hooks/useI18n'
+import { objectIdRegex } from 'app/utils/idPrefixes'
 
 export function ObjectIdFilter() {
   const { t } = useI18n()
@@ -15,7 +12,7 @@ export function ObjectIdFilter() {
       title={t('filterByObjectId')}
       label={t('objectId')}
       queryParam={QueryParams.ObjectId}
-      regex={RegExp(`^(?:${GO_PREFIX}|${UNIPROTKB_PREFIX}).+$`)}
+      regex={objectIdRegex}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/DepositionFilter/DepositionIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/DepositionFilter/DepositionIdFilter.tsx
@@ -1,5 +1,4 @@
 import { EntityIdFilter } from 'app/components/Filters'
-import { IdPrefix } from 'app/constants/idPrefixes'
 import { QueryParams } from 'app/constants/query'
 import { useI18n } from 'app/hooks/useI18n'
 
@@ -12,7 +11,6 @@ export function DepositionIdFilter() {
       title={t('filterByDepositionId')}
       label={t('depositionId')}
       queryParam={QueryParams.DepositionId}
-      prefix={IdPrefix.Deposition}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
@@ -2,12 +2,16 @@ import { Button, Icon } from '@czi-sds/components'
 import Popover from '@mui/material/Popover'
 import { ReactNode, useRef, useState } from 'react'
 
+import { QueryParams } from 'app/constants/query'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
 
+import { getPrefixedId } from './utils'
+
 export interface ActiveDropdownFilterData {
-  value: string
   label?: string
+  queryParam: QueryParams
+  value: string
 }
 
 export function DropdownFilterButton({
@@ -71,35 +75,38 @@ export function DropdownFilterButton({
       {/* active filter chips  */}
       {activeFilters.length > 0 && (
         <div className="flex flex-col gap-sds-xs">
-          {activeFilters.map((filter) => (
-            <div className="pl-sds-s flex flex-col">
-              {filter.label && (
-                <p className="text-sds-body-xs leading-sds-body-xs text-sds-gray-500 uppercase">
-                  {filter.label}
-                </p>
-              )}
+          {activeFilters.map((filter) => {
+            return (
+              <div className="pl-sds-s flex flex-col">
+                {filter.label && (
+                  <p className="text-sds-body-xs leading-sds-body-xs text-sds-gray-500 uppercase">
+                    {filter.label}
+                  </p>
+                )}
 
-              <div>
-                <div className="bg-sds-primary-400 rounded-sds-m py-sds-xxs px-sds-s inline-flex items-center gap-sds-s">
-                  <span className="text-sds-body-xs leading-sds-body-xs font-semibold text-white">
-                    {filter.value}
-                  </span>
+                <div>
+                  <div className="bg-sds-primary-400 rounded-sds-m py-sds-xxs px-sds-s inline-flex items-center gap-sds-s">
+                    <span className="text-sds-body-xs leading-sds-body-xs font-semibold text-white">
+                      {/* {filter.value} */}
+                      {getPrefixedId(filter.queryParam, filter.value)}
+                    </span>
 
-                  <Button
-                    className="!min-w-0 !w-0"
-                    onClick={() => onRemoveFilter(filter)}
-                  >
-                    <Icon
-                      className="!fill-white !w-[10px] !h-[10px]"
-                      sdsIcon="xMark"
-                      sdsSize="xs"
-                      sdsType="static"
-                    />
-                  </Button>
+                    <Button
+                      className="!min-w-0 !w-0"
+                      onClick={() => onRemoveFilter(filter)}
+                    >
+                      <Icon
+                        className="!fill-white !w-[10px] !h-[10px]"
+                        sdsIcon="xMark"
+                        sdsSize="xs"
+                        sdsType="static"
+                      />
+                    </Button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
@@ -9,7 +9,7 @@ import { getPrefixedId } from 'app/utils/idPrefixes'
 
 export interface ActiveDropdownFilterData {
   label?: string
-  queryParam: QueryParams
+  queryParam?: QueryParams
   value: string
 }
 
@@ -86,7 +86,7 @@ export function DropdownFilterButton({
                 <div>
                   <div className="bg-sds-primary-400 rounded-sds-m py-sds-xxs px-sds-s inline-flex items-center gap-sds-s">
                     <span className="text-sds-body-xs leading-sds-body-xs font-semibold text-white">
-                      {getPrefixedId(filter.queryParam, filter.value)}
+                      {getPrefixedId(filter.value, filter.queryParam)}
                     </span>
 
                     <Button

--- a/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/DropdownFilterButton.tsx
@@ -5,8 +5,7 @@ import { ReactNode, useRef, useState } from 'react'
 import { QueryParams } from 'app/constants/query'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
-
-import { getPrefixedId } from './utils'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 export interface ActiveDropdownFilterData {
   label?: string
@@ -87,7 +86,6 @@ export function DropdownFilterButton({
                 <div>
                   <div className="bg-sds-primary-400 rounded-sds-m py-sds-xxs px-sds-s inline-flex items-center gap-sds-s">
                     <span className="text-sds-body-xs leading-sds-body-xs font-semibold text-white">
-                      {/* {filter.value} */}
                       {getPrefixedId(filter.queryParam, filter.value)}
                     </span>
 

--- a/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
@@ -35,8 +35,8 @@ export function EntityIdFilter({
       title={title}
       queryParam={queryParam}
       regex={validationRegex}
-      displayNormalizer={(value) => getPrefixedId(queryParam, value)}
-      paramNormalizer={(value) => removeIdPrefix(queryParam, value) ?? ''}
+      displayNormalizer={(value) => getPrefixedId(value, queryParam)}
+      paramNormalizer={(value) => removeIdPrefix(value, queryParam) ?? ''}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
@@ -3,10 +3,10 @@ import { useMemo } from 'react'
 import { QueryParams } from 'app/constants/query'
 import {
   allDigitsRegex,
-  extractNumericId,
   getEntityIdPrefixRegex,
   getPrefixedId,
   QueryParamToIdPrefixMap,
+  removeIdPrefix,
 } from 'app/utils/idPrefixes'
 
 import { RegexFilter } from './RegexFilter'
@@ -36,7 +36,7 @@ export function EntityIdFilter({
       queryParam={queryParam}
       regex={validationRegex}
       displayNormalizer={(value) => getPrefixedId(queryParam, value)}
-      paramNormalizer={(value) => extractNumericId(value) ?? ''}
+      paramNormalizer={(value) => removeIdPrefix(queryParam, value) ?? ''}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from 'react'
 
-import { IdPrefix } from 'app/constants/idPrefixes'
 import { QueryParams } from 'app/constants/query'
+import {
+  extractNumericId,
+  getPrefixedId,
+  QueryParamToIdPrefixMap,
+} from 'app/utils/idPrefixes'
 
 import { RegexFilter } from './RegexFilter'
 
@@ -10,14 +14,13 @@ export function EntityIdFilter({
   label,
   title,
   queryParam,
-  prefix,
 }: {
   id: string
   label: string
   title: string
   queryParam: QueryParams
-  prefix?: IdPrefix
 }) {
+  const prefix = QueryParamToIdPrefixMap[queryParam]
   const validationRegex = useMemo(
     () => (prefix ? RegExp(`^(${prefix}-)?\\d+$`, 'i') : /^\d+$/),
     [prefix],
@@ -30,12 +33,8 @@ export function EntityIdFilter({
       title={title}
       queryParam={queryParam}
       regex={validationRegex}
-      displayNormalizer={(value) =>
-        prefix && value.startsWith(prefix) ? value : `${prefix}-${value}`
-      }
-      paramNormalizer={(value) =>
-        value.replace(new RegExp(`^${prefix}-`, 'i'), '')
-      }
+      displayNormalizer={(value) => getPrefixedId(queryParam, value)}
+      paramNormalizer={(value) => extractNumericId(value) ?? ''}
     />
   )
 }

--- a/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
@@ -2,7 +2,9 @@ import { useMemo } from 'react'
 
 import { QueryParams } from 'app/constants/query'
 import {
+  allDigitsRegex,
   extractNumericId,
+  getEntityIdPrefixRegex,
   getPrefixedId,
   QueryParamToIdPrefixMap,
 } from 'app/utils/idPrefixes'
@@ -22,7 +24,7 @@ export function EntityIdFilter({
 }) {
   const prefix = QueryParamToIdPrefixMap[queryParam]
   const validationRegex = useMemo(
-    () => (prefix ? RegExp(`^(${prefix}-)?\\d+$`, 'i') : /^\d+$/),
+    () => (prefix ? getEntityIdPrefixRegex(prefix) : allDigitsRegex),
     [prefix],
   )
 

--- a/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/EntityIdFilter.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { QueryParams } from 'app/constants/query'
 import {
-  allDigitsRegex,
+  ALL_DIGITS_REGEX,
   getEntityIdPrefixRegex,
   getPrefixedId,
   QueryParamToIdPrefixMap,
@@ -24,7 +24,7 @@ export function EntityIdFilter({
 }) {
   const prefix = QueryParamToIdPrefixMap[queryParam]
   const validationRegex = useMemo(
-    () => (prefix ? getEntityIdPrefixRegex(prefix) : allDigitsRegex),
+    () => (prefix ? getEntityIdPrefixRegex(prefix) : ALL_DIGITS_REGEX),
     [prefix],
   )
 

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { QueryParams } from 'app/constants/query'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
-import { extractNumericId } from 'app/utils/idPrefixes'
+import { extractNumericId, isFilterPrefixValid } from 'app/utils/idPrefixes'
 
 import { DropdownFilterButton } from './DropdownFilterButton'
 import { InputFilter } from './InputFilter'
@@ -43,10 +43,13 @@ export function MultiInputFilter({
 
   const [values, setValues] = useState(getQueryParamValues)
 
-  const isDisabled = useMemo(
-    () => isEqual(values, getQueryParamValues()),
-    [getQueryParamValues, values],
-  )
+  const isDisabled = useMemo(() => {
+    const hasInvalidPrefix = !!filters.find(
+      (filter) => !isFilterPrefixValid(filter.queryParam, values[filter.id]),
+    )
+
+    return hasInvalidPrefix || isEqual(values, getQueryParamValues())
+  }, [filters, getQueryParamValues, values])
 
   return (
     <DropdownFilterButton

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -8,6 +8,7 @@ import { cns } from 'app/utils/cns'
 
 import { DropdownFilterButton } from './DropdownFilterButton'
 import { InputFilter } from './InputFilter'
+import { extractNumericId } from './utils'
 
 export interface InputFilterData {
   id: string
@@ -54,6 +55,7 @@ export function MultiInputFilter({
         .map((filter) => ({
           label: filters.length > 1 ? filter.label : '',
           value: values[filter.id],
+          queryParam: filter.queryParam,
         }))}
       description={
         <>
@@ -74,7 +76,9 @@ export function MultiInputFilter({
             const value = values[filter.id]
 
             if (value) {
-              prev.set(filter.queryParam, value)
+              // Our filters currently support numeric IDs and use the queryParam as the key
+              // The filter will show the prefix, but we do not need to store it in the query params
+              prev.set(filter.queryParam, extractNumericId(value) ?? '')
             }
           })
 

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -5,10 +5,10 @@ import { useCallback, useMemo, useState } from 'react'
 import { QueryParams } from 'app/constants/query'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
+import { extractNumericId } from 'app/utils/idPrefixes'
 
 import { DropdownFilterButton } from './DropdownFilterButton'
 import { InputFilter } from './InputFilter'
-import { extractNumericId } from './utils'
 
 export interface InputFilterData {
   id: string

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -45,7 +45,7 @@ export function MultiInputFilter({
 
   const isDisabled = useMemo(() => {
     const hasInvalidPrefix = !!filters.find(
-      (filter) => !isFilterPrefixValid(filter.queryParam, values[filter.id]),
+      (filter) => !isFilterPrefixValid(values[filter.id], filter.queryParam),
     )
 
     return hasInvalidPrefix || isEqual(values, getQueryParamValues())

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -83,7 +83,7 @@ export function MultiInputFilter({
               // The filter will show the prefix, but we do not need to store it in the query params
               prev.set(
                 filter.queryParam,
-                removeIdPrefix(filter.queryParam, value) ?? '',
+                removeIdPrefix(value, filter.queryParam) ?? '',
               )
             }
           })

--- a/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/MultiInputFilter.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { QueryParams } from 'app/constants/query'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
-import { extractNumericId, isFilterPrefixValid } from 'app/utils/idPrefixes'
+import { isFilterPrefixValid, removeIdPrefix } from 'app/utils/idPrefixes'
 
 import { DropdownFilterButton } from './DropdownFilterButton'
 import { InputFilter } from './InputFilter'
@@ -81,7 +81,10 @@ export function MultiInputFilter({
             if (value) {
               // Our filters currently support numeric IDs and use the queryParam as the key
               // The filter will show the prefix, but we do not need to store it in the query params
-              prev.set(filter.queryParam, extractNumericId(value) ?? '')
+              prev.set(
+                filter.queryParam,
+                removeIdPrefix(filter.queryParam, value) ?? '',
+              )
             }
           })
 

--- a/frontend/packages/data-portal/app/components/Filters/RegexFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/RegexFilter.tsx
@@ -43,7 +43,7 @@ export function RegexFilter({
 
   return (
     <DropdownFilterButton
-      activeFilters={paramValue ? [{ value: displayValue }] : []}
+      activeFilters={paramValue ? [{ value: displayValue, queryParam }] : []}
       description={
         <>
           <p className="text-sds-header-xs leading-sds-header-xs font-semibold">

--- a/frontend/packages/data-portal/app/components/Filters/utils.ts
+++ b/frontend/packages/data-portal/app/components/Filters/utils.ts
@@ -1,0 +1,23 @@
+// This function takes an id string and returns the numeric portion of the id.
+
+import { QueryParams } from 'app/constants/query'
+
+// Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
+export function extractNumericId(id: string) {
+  // Use a regular expression to match the numeric portion of the ID
+  const match = id.match(/\d+/)
+
+  // If a match is found, return it, otherwise return null
+  return match ? match[0] : null
+}
+
+export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, string>> = {
+  [QueryParams.DatasetId]: 'DS',
+}
+
+export function getPrefixedId(queryParam: QueryParams, id: string) {
+  // ID may or may not already be prefixed, so take it off just in case
+  const cleanId = extractNumericId(id)
+  const prefix = QueryParamToIdPrefixMap[queryParam] ?? ''
+  return prefix ? `${prefix}-${cleanId}` : id
+}

--- a/frontend/packages/data-portal/app/constants/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/constants/idPrefixes.ts
@@ -1,3 +1,7 @@
 export enum IdPrefix {
+  Annotation = 'AN',
+  Dataset = 'DS',
   Deposition = 'CZCDP',
+  Run = 'RN',
+  TiltSeries = 'TS',
 }

--- a/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
@@ -1,6 +1,10 @@
 import { QueryParams } from 'app/constants/query'
 
-import { extractNumericId, getPrefixedId } from './idPrefixes'
+import {
+  extractNumericId,
+  getPrefixedId,
+  isFilterPrefixValid,
+} from './idPrefixes'
 
 describe('extractNumericId()', () => {
   it('should extract numeric id from string', () => {
@@ -41,6 +45,28 @@ describe('getPrefixedId()', () => {
 
     testCases.forEach((testCase) =>
       expect(getPrefixedId(testCase.queryParam, testCase.id)).toEqual(
+        testCase.output,
+      ),
+    )
+  })
+})
+
+describe('isFilterPrefixValid()', () => {
+  it('should validate filter prefix', () => {
+    const testCases = [
+      {
+        queryParam: QueryParams.DepositionId,
+        value: 'CZCDP-123',
+        output: true,
+      },
+      { queryParam: QueryParams.DepositionId, value: '123', output: true },
+      { queryParam: QueryParams.AnnotationId, value: 'AN123', output: true },
+      { queryParam: QueryParams.AnnotationId, value: 'NAN-123', output: false },
+      { queryParam: QueryParams.DatasetId, value: '1-23', output: false },
+    ]
+
+    testCases.forEach((testCase) =>
+      expect(isFilterPrefixValid(testCase.queryParam, testCase.value)).toEqual(
         testCase.output,
       ),
     )

--- a/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
@@ -37,7 +37,7 @@ describe('removeIdPrefix()', () => {
     ]
 
     testCases.forEach((testCase) =>
-      expect(removeIdPrefix(testCase.queryParam, testCase.input)).toEqual(
+      expect(removeIdPrefix(testCase.input, testCase.queryParam)).toEqual(
         testCase.output,
       ),
     )
@@ -52,7 +52,7 @@ describe('removeIdPrefix()', () => {
     ]
 
     testCases.forEach((testCase) =>
-      expect(removeIdPrefix(testCase.queryParam, testCase.input)).toEqual(
+      expect(removeIdPrefix(testCase.input, testCase.queryParam)).toEqual(
         testCase.output,
       ),
     )
@@ -81,7 +81,7 @@ describe('getPrefixedId()', () => {
     ]
 
     testCases.forEach((testCase) =>
-      expect(getPrefixedId(testCase.queryParam, testCase.id)).toEqual(
+      expect(getPrefixedId(testCase.id, testCase.queryParam)).toEqual(
         testCase.output,
       ),
     )

--- a/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
@@ -1,23 +1,60 @@
 import { QueryParams } from 'app/constants/query'
 
 import {
-  extractNumericId,
   getPrefixedId,
   isFilterPrefixValid,
+  removeIdPrefix,
 } from './idPrefixes'
 
-describe('extractNumericId()', () => {
+describe('removeIdPrefix()', () => {
   it('should extract numeric id from string', () => {
     const testCases = [
-      { input: 'id1', output: '1' },
-      { input: 'id-123', output: '123' },
-      { input: 'id-1234', output: '1234' },
-      { input: 'xyz-123', output: '123' },
-      { input: 'id-0008', output: '0008' },
+      {
+        queryParam: QueryParams.DepositionId,
+        input: 'id1',
+        output: '1',
+      },
+      {
+        queryParam: QueryParams.DatasetId,
+        input: 'id-123',
+        output: '123',
+      },
+      {
+        queryParam: QueryParams.AnnotationId,
+        input: 'id-1234',
+        output: '1234',
+      },
+      {
+        queryParam: QueryParams.DepositionId,
+        input: 'xyz-123',
+        output: '123',
+      },
+      {
+        queryParam: QueryParams.DepositionId,
+        input: 'id-0008',
+        output: '0008',
+      },
     ]
 
     testCases.forEach((testCase) =>
-      expect(extractNumericId(testCase.input)).toEqual(testCase.output),
+      expect(removeIdPrefix(testCase.queryParam, testCase.input)).toEqual(
+        testCase.output,
+      ),
+    )
+  })
+  it('should return the same string if the queryParam does not have a prefix', () => {
+    const testCases = [
+      {
+        queryParam: QueryParams.AuthorName,
+        input: 'Jane Doe',
+        output: 'Jane Doe',
+      },
+    ]
+
+    testCases.forEach((testCase) =>
+      expect(removeIdPrefix(testCase.queryParam, testCase.input)).toEqual(
+        testCase.output,
+      ),
     )
   })
 })

--- a/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
@@ -103,7 +103,7 @@ describe('isFilterPrefixValid()', () => {
     ]
 
     testCases.forEach((testCase) =>
-      expect(isFilterPrefixValid(testCase.queryParam, testCase.value)).toEqual(
+      expect(isFilterPrefixValid(testCase.value, testCase.queryParam)).toEqual(
         testCase.output,
       ),
     )

--- a/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.test.ts
@@ -1,0 +1,48 @@
+import { QueryParams } from 'app/constants/query'
+
+import { extractNumericId, getPrefixedId } from './idPrefixes'
+
+describe('extractNumericId()', () => {
+  it('should extract numeric id from string', () => {
+    const testCases = [
+      { input: 'id1', output: '1' },
+      { input: 'id-123', output: '123' },
+      { input: 'id-1234', output: '1234' },
+      { input: 'xyz-123', output: '123' },
+      { input: 'id-0008', output: '0008' },
+    ]
+
+    testCases.forEach((testCase) =>
+      expect(extractNumericId(testCase.input)).toEqual(testCase.output),
+    )
+  })
+})
+
+describe('getPrefixedId()', () => {
+  it('should add prefix to id', () => {
+    const testCases = [
+      { queryParam: QueryParams.DepositionId, id: '123', output: 'CZCDP-123' },
+      {
+        queryParam: QueryParams.DepositionId,
+        id: 'deposition-123',
+        output: 'CZCDP-123',
+      },
+      {
+        queryParam: QueryParams.DepositionId,
+        id: 'deposition-123-456',
+        output: 'CZCDP-123456',
+      },
+      {
+        queryParam: QueryParams.DepositionId,
+        id: 'deposition-0008',
+        output: 'CZCDP-0008',
+      },
+    ]
+
+    testCases.forEach((testCase) =>
+      expect(getPrefixedId(testCase.queryParam, testCase.id)).toEqual(
+        testCase.output,
+      ),
+    )
+  })
+})

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -43,7 +43,8 @@ export const getEntityIdPrefixRegex = (prefix: string) =>
 export const allDigitsRegex = /^\d+$/
 export const objectIdRegex = RegExp(`^(?:${GO_PREFIX}|${UNIPROTKB_PREFIX}).+$`)
 
-export function isFilterPrefixValid(queryParam: QueryParams, value: string) {
+export function isFilterPrefixValid(value: string, queryParam?: QueryParams) {
+  if (!queryParam || value === '') return true
   const prefix = QueryParamToIdPrefixMap[queryParam]
   if (!prefix) return true
 

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -5,16 +5,6 @@ import {
 import { IdPrefix } from 'app/constants/idPrefixes'
 import { QueryParams } from 'app/constants/query'
 
-// This function takes an id string and returns the all numeric portions of the id.
-// Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
-export function extractNumericId(id: string) {
-  // Use a regular expression to match the numeric portion of the ID
-  const matches = id.match(/\d+/g)
-
-  // If a match is found, return it, otherwise return null
-  return matches ? matches.join('') : null
-}
-
 // TODO: as we add more prefixes, we need to update this map
 export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
   [QueryParams.AnnotationId]: IdPrefix.Annotation,
@@ -23,9 +13,22 @@ export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
   // Currently we cannot filter by Run or Tiltseries ID, so they are not here
 }
 
+// This function takes an id string and returns the all numeric portions of the id.
+// Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
+export function removeIdPrefix(queryParam: QueryParams, value: string) {
+  const prefix = QueryParamToIdPrefixMap[queryParam]
+  if (!prefix) return value
+
+  // Use a regular expression to match the numeric portion of the ID
+  const matches = value.match(/\d+/g)
+
+  // If a match is found, return it, otherwise return null
+  return matches ? matches.join('') : null
+}
+
 export function getPrefixedId(queryParam: QueryParams, id: string) {
   // ID may or may not already be prefixed, so take it off just in case
-  const cleanId = extractNumericId(id)
+  const cleanId = removeIdPrefix(queryParam, id)
   const prefix = QueryParamToIdPrefixMap[queryParam] ?? ''
   return prefix ? `${prefix}-${cleanId}` : id
 }

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -13,7 +13,10 @@ export function extractNumericId(id: string) {
 
 // TODO: as we add more prefixes, we need to update this map
 export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
+  [QueryParams.AnnotationId]: IdPrefix.Annotation,
+  [QueryParams.DatasetId]: IdPrefix.Dataset,
   [QueryParams.DepositionId]: IdPrefix.Deposition,
+  // Currently we cannot filter by Run or Tiltseries ID, so they are not here
 }
 
 export function getPrefixedId(queryParam: QueryParams, id: string) {

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -40,8 +40,10 @@ export function getPrefixedId(id: string, queryParam?: QueryParams) {
 export const getEntityIdPrefixRegex = (prefix: string) =>
   RegExp(`^(${prefix})?(-)?\\d+$`, 'i')
 
-export const allDigitsRegex = /^\d+$/
-export const objectIdRegex = RegExp(`^(?:${GO_PREFIX}|${UNIPROTKB_PREFIX}).+$`)
+export const ALL_DIGITS_REGEX = /^\d+$/
+export const OBJECT_ID_REGEX = RegExp(
+  `^(?:${GO_PREFIX}|${UNIPROTKB_PREFIX}).+$`,
+)
 
 export function isFilterPrefixValid(value: string, queryParam?: QueryParams) {
   if (!queryParam || value === '') return true

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -1,3 +1,7 @@
+import {
+  GO_PREFIX,
+  UNIPROTKB_PREFIX,
+} from 'app/constants/annotationObjectIdLinks'
 import { IdPrefix } from 'app/constants/idPrefixes'
 import { QueryParams } from 'app/constants/query'
 
@@ -24,4 +28,18 @@ export function getPrefixedId(queryParam: QueryParams, id: string) {
   const cleanId = extractNumericId(id)
   const prefix = QueryParamToIdPrefixMap[queryParam] ?? ''
   return prefix ? `${prefix}-${cleanId}` : id
+}
+
+export const getEntityIdPrefixRegex = (prefix: string) =>
+  RegExp(`^(${prefix})?(-)?\\d+$`, 'i')
+
+export const allDigitsRegex = /^\d+$/
+export const objectIdRegex = RegExp(`^(?:${GO_PREFIX}|${UNIPROTKB_PREFIX}).+$`)
+
+export function isFilterPrefixValid(queryParam: QueryParams, value: string) {
+  const prefix = QueryParamToIdPrefixMap[queryParam]
+  if (!prefix) return true
+
+  const validationRegex = prefix ? getEntityIdPrefixRegex(prefix) : /^\d+$/
+  return validationRegex.test(value)
 }

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -1,18 +1,19 @@
-// This function takes an id string and returns the numeric portion of the id.
-
+import { IdPrefix } from 'app/constants/idPrefixes'
 import { QueryParams } from 'app/constants/query'
 
+// This function takes an id string and returns the all numeric portions of the id.
 // Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
 export function extractNumericId(id: string) {
   // Use a regular expression to match the numeric portion of the ID
-  const match = id.match(/\d+/)
+  const matches = id.match(/\d+/g)
 
   // If a match is found, return it, otherwise return null
-  return match ? match[0] : null
+  return matches ? matches.join('') : null
 }
 
-export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, string>> = {
-  [QueryParams.DatasetId]: 'DS',
+// TODO: as we add more prefixes, we need to update this map
+export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
+  [QueryParams.DepositionId]: IdPrefix.Deposition,
 }
 
 export function getPrefixedId(queryParam: QueryParams, id: string) {

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -13,8 +13,10 @@ export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
   // Currently we cannot filter by Run or Tiltseries ID, so they are not here
 }
 
-// This function takes an id string and returns the all numeric portions of the id.
+// This function takes a value string and returns the all non-prefix portions.
 // Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
+// Inputs can also be strings like "Author Name"
+// NOTE: If we need prefixes for string values, like "PREFIX-Author Name", we will need to update this function
 export function removeIdPrefix(value: string, queryParam?: QueryParams) {
   if (!queryParam) return value
   const prefix = QueryParamToIdPrefixMap[queryParam]

--- a/frontend/packages/data-portal/app/utils/idPrefixes.ts
+++ b/frontend/packages/data-portal/app/utils/idPrefixes.ts
@@ -15,7 +15,8 @@ export const QueryParamToIdPrefixMap: Partial<Record<QueryParams, IdPrefix>> = {
 
 // This function takes an id string and returns the all numeric portions of the id.
 // Inputs can be in the form of "id-123", "123", "id123", or "id-123-456"
-export function removeIdPrefix(queryParam: QueryParams, value: string) {
+export function removeIdPrefix(value: string, queryParam?: QueryParams) {
+  if (!queryParam) return value
   const prefix = QueryParamToIdPrefixMap[queryParam]
   if (!prefix) return value
 
@@ -26,9 +27,10 @@ export function removeIdPrefix(queryParam: QueryParams, value: string) {
   return matches ? matches.join('') : null
 }
 
-export function getPrefixedId(queryParam: QueryParams, id: string) {
+export function getPrefixedId(id: string, queryParam?: QueryParams) {
+  if (!queryParam) return id
   // ID may or may not already be prefixed, so take it off just in case
-  const cleanId = removeIdPrefix(queryParam, id)
+  const cleanId = removeIdPrefix(id, queryParam)
   const prefix = QueryParamToIdPrefixMap[queryParam] ?? ''
   return prefix ? `${prefix}-${cleanId}` : id
 }

--- a/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
@@ -2,16 +2,14 @@ import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { test } from '@playwright/test'
 import { FiltersActor } from 'e2e/pageObjects/filters/filtersActor'
 import { FiltersPage } from 'e2e/pageObjects/filters/filtersPage'
-import {
-  getPrefixedId,
-  serializeAvailableFiles,
-} from 'e2e/pageObjects/filters/utils'
+import { serializeAvailableFiles } from 'e2e/pageObjects/filters/utils'
 
 import { QueryParams } from 'app/constants/query'
 
 import { getApolloClient } from './apollo'
 import { BROWSE_DATASETS_URL, E2E_CONFIG, translations } from './constants'
 import { onlyRunIfEnabled } from './utils'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 test.describe('Browse datasets page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -1155,10 +1153,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.expectFilterTagToExist(
-          getPrefixedId({
-            id: E2E_CONFIG.depositionId,
-            prefixKey: 'Deposition',
-          }),
+          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
         )
 
         // TODO: (kne42) uncomment when hooked up to backend
@@ -1185,10 +1180,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.expectFilterTagToExist(
-          getPrefixedId({
-            id: E2E_CONFIG.depositionId,
-            prefixKey: 'Deposition',
-          }),
+          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
         )
 
         // TODO: (kne42) uncomment when hooked up to backend
@@ -1215,10 +1207,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.removeMultiInputFilter(
-          getPrefixedId({
-            id: E2E_CONFIG.depositionId,
-            prefixKey: 'Deposition',
-          }),
+          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
         )
 
         await filtersActor.expectUrlQueryParamsToBeCorrect({

--- a/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
@@ -1153,7 +1153,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.expectFilterTagToExist(
-          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+          getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
         )
 
         // TODO: (kne42) uncomment when hooked up to backend
@@ -1180,7 +1180,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.expectFilterTagToExist(
-          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+          getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
         )
 
         // TODO: (kne42) uncomment when hooked up to backend
@@ -1207,7 +1207,7 @@ test.describe('Browse datasets page filters', () => {
         })
 
         await filtersPage.removeMultiInputFilter(
-          getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+          getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
         )
 
         await filtersActor.expectUrlQueryParamsToBeCorrect({

--- a/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/browseDatasetFilters.test.ts
@@ -5,11 +5,11 @@ import { FiltersPage } from 'e2e/pageObjects/filters/filtersPage'
 import { serializeAvailableFiles } from 'e2e/pageObjects/filters/utils'
 
 import { QueryParams } from 'app/constants/query'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 import { getApolloClient } from './apollo'
 import { BROWSE_DATASETS_URL, E2E_CONFIG, translations } from './constants'
 import { onlyRunIfEnabled } from './utils'
-import { getPrefixedId } from 'app/utils/idPrefixes'
 
 test.describe('Browse datasets page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
@@ -72,16 +72,6 @@ export function getExpectedTotalCount({
   )
 }
 
-export function getPrefixedId({
-  id,
-  prefixKey,
-}: {
-  id: string
-  prefixKey: keyof typeof IdPrefix
-}): string {
-  return `${IdPrefix[prefixKey]}-${id}`
-}
-
 // #Region runPage
 export function getAnnotationRowCountFromData({
   singleRunData,

--- a/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/filters/utils.ts
@@ -8,7 +8,6 @@ import {
   GetRunByIdQuery,
 } from 'app/__generated__/graphql'
 import { AVAILABLE_FILES_VALUE_TO_I18N_MAP } from 'app/components/DatasetFilter/constants'
-import { IdPrefix } from 'app/constants/idPrefixes'
 
 import { QueryParamObjectType, RowCounterType } from './types'
 

--- a/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
@@ -4,11 +4,11 @@ import { FiltersActor } from 'e2e/pageObjects/filters/filtersActor'
 import { FiltersPage } from 'e2e/pageObjects/filters/filtersPage'
 
 import { QueryParams } from 'app/constants/query'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 import { getApolloClient } from './apollo'
 import { E2E_CONFIG, SINGLE_DATASET_URL, translations } from './constants'
 import { onlyRunIfEnabled } from './utils'
-import { getPrefixedId } from 'app/utils/idPrefixes'
 
 test.describe('Single dataset page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>

--- a/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
@@ -2,13 +2,13 @@ import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { test } from '@playwright/test'
 import { FiltersActor } from 'e2e/pageObjects/filters/filtersActor'
 import { FiltersPage } from 'e2e/pageObjects/filters/filtersPage'
-import { getPrefixedId } from 'e2e/pageObjects/filters/utils'
 
 import { QueryParams } from 'app/constants/query'
 
 import { getApolloClient } from './apollo'
 import { E2E_CONFIG, SINGLE_DATASET_URL, translations } from './constants'
 import { onlyRunIfEnabled } from './utils'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 test.describe('Single dataset page filters', () => {
   let client: ApolloClient<NormalizedCacheObject>
@@ -134,10 +134,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId({
-          id: E2E_CONFIG.depositionId,
-          prefixKey: 'Deposition',
-        }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       // TODO: (kne42) uncomment this when hooked up to backend
@@ -165,10 +162,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId({
-          id: E2E_CONFIG.depositionId,
-          prefixKey: 'Deposition',
-        }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       // TODO: (kne42) uncomment this when hooked up to backend
@@ -196,10 +190,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.removeMultiInputFilter(
-        getPrefixedId({
-          id: E2E_CONFIG.depositionId,
-          prefixKey: 'Deposition',
-        }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       await filtersActor.expectUrlQueryParamsToBeCorrect({

--- a/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleDatasetFilters.test.ts
@@ -134,7 +134,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       // TODO: (kne42) uncomment this when hooked up to backend
@@ -162,7 +162,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       // TODO: (kne42) uncomment this when hooked up to backend
@@ -190,7 +190,7 @@ test.describe('Single dataset page filters', () => {
       })
 
       await filtersPage.removeMultiInputFilter(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       await filtersActor.expectUrlQueryParamsToBeCorrect({

--- a/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
@@ -2,9 +2,9 @@ import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { test } from '@playwright/test'
 import { FiltersActor } from 'e2e/pageObjects/filters/filtersActor'
 import { FiltersPage } from 'e2e/pageObjects/filters/filtersPage'
-import { getPrefixedId } from 'e2e/pageObjects/filters/utils'
 
 import { QueryParams } from 'app/constants/query'
+import { getPrefixedId } from 'app/utils/idPrefixes'
 
 import { getApolloClient } from './apollo'
 import { E2E_CONFIG, SINGLE_RUN_URL, translations } from './constants'
@@ -239,10 +239,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId({
-          id: E2E_CONFIG.depositionId,
-          prefixKey: 'Deposition',
-        }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       // TODO: (kne42) uncomment when hooked up to backend
@@ -270,10 +267,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId({
-          id: E2E_CONFIG.depositionId,
-          prefixKey: 'Deposition',
-        }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       // TODO: (kne42) uncomment when hooked up to backend
@@ -301,7 +295,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.removeMultiInputFilter(
-        getPrefixedId({ id: E2E_CONFIG.depositionId, prefixKey: 'Deposition' }),
+        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
       )
 
       await filtersActor.expectUrlQueryParamsToBeCorrect({

--- a/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
+++ b/frontend/packages/data-portal/e2e/singleRunFilters.test.ts
@@ -239,7 +239,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       // TODO: (kne42) uncomment when hooked up to backend
@@ -267,7 +267,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.expectFilterTagToExist(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       // TODO: (kne42) uncomment when hooked up to backend
@@ -295,7 +295,7 @@ test.describe('Single run page filters', () => {
       })
 
       await filtersPage.removeMultiInputFilter(
-        getPrefixedId(QueryParams.DepositionId, E2E_CONFIG.depositionId),
+        getPrefixedId(E2E_CONFIG.depositionId, QueryParams.DepositionId),
       )
 
       await filtersActor.expectUrlQueryParamsToBeCorrect({


### PR DESCRIPTION
Issue #1015 

When filtering by an id, do not include the prefix in the url query params.  Do include the prefix in the display chip for active filters.

Note: Does this need to be behind a feature flag?

![id-prefixes](https://github.com/user-attachments/assets/e37da985-db75-432d-8068-42c15f3470fd)
