### PR TITLE
fix: Fix not enough padding below key photos

### DIFF
--- a/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
+++ b/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
@@ -8,7 +8,7 @@ export interface HeaderKeyPhotoProps {
 
 export function HeaderKeyPhoto({ url, title }: HeaderKeyPhotoProps) {
   return (
-    <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m">
+    <div className="max-w-[465px] max-h-[330px] grow">
       {url !== undefined ? (
         <Link to={url}>
           <KeyPhoto title={title} src={url} />

--- a/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
+++ b/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
@@ -8,7 +8,7 @@ export interface HeaderKeyPhotoProps {
 
 export function HeaderKeyPhoto({ url, title }: HeaderKeyPhotoProps) {
   return (
-    <div className="max-w-[465px] max-h-[330px] grow">
+    <div className="max-w-[465px] grow">
       {url !== undefined ? (
         <Link to={url}>
           <KeyPhoto title={title} src={url} />

--- a/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
+++ b/frontend/packages/data-portal/app/components/HeaderKeyPhoto.tsx
@@ -8,7 +8,7 @@ export interface HeaderKeyPhotoProps {
 
 export function HeaderKeyPhoto({ url, title }: HeaderKeyPhotoProps) {
   return (
-    <div className="max-w-[465px] max-h-[330px] grow">
+    <div className="max-w-[465px] max-h-[330px] grow overflow-clip rounded-sds-m">
       {url !== undefined ? (
         <Link to={url}>
           <KeyPhoto title={title} src={url} />


### PR DESCRIPTION
I'm not sure why the `max-h-[330px]` was there before, but `<KeyPhoto>` already controls the sizing and aspect ratio stuff so `max-w` should be enough...

Before: 
<img width="609" alt="image" src="https://github.com/user-attachments/assets/9dce0f11-c07d-489d-bf70-188e515064c3">

After:
<img width="727" alt="image" src="https://github.com/user-attachments/assets/34cff251-c88c-4404-a4e7-212dced14170">


