### PR TITLE
ci: remove glob path pattern for python client tests workflow

### DIFF
--- a/.github/workflows/client-python.yml
+++ b/.github/workflows/client-python.yml
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - 'client/python/**'
-      - '.github/workflows/**'
+      - '.github/workflows/client-python.yml'
   pull_request:
     branches:
       - '**'
     paths:
       - 'client/python/**'
-      - '.github/workflows/**'
+      - '.github/workflows/client-python.yml'
 
 jobs:
   test-client-python:


### PR DESCRIPTION
We shouldn't need to run the Python client tests whenever we change a workflow file for something like the frontend deployment 🤣 