### PR TITLE
fix: Stop querying depositionTitle

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
+++ b/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
@@ -67,7 +67,7 @@ export function TomogramMetadataDrawer() {
           {
             label: t('depositionName'),
             // TODO(bchu): Uncomment after API field name change is in prod.
-            // values: [tomogram.deposition?.depositionTitle ?? ''],
+            // values: [tomogram.deposition?.title ?? ''],
             values: [],
             renderValue: (value: string) => (
               <Link

--- a/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
+++ b/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
@@ -66,7 +66,9 @@ export function TomogramMetadataDrawer() {
           },
           {
             label: t('depositionName'),
-            values: [tomogram.deposition?.depositionTitle ?? ''],
+            // TODO(bchu): Uncomment after API field name change is in prod.
+            // values: [tomogram.deposition?.depositionTitle ?? ''],
+            values: [],
             renderValue: (value: string) => (
               <Link
                 className="text-sds-color-primitive-blue-400"

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -213,7 +213,7 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
         deposition {
           id
           depositionDate
-          depositionTitle
+          # title # TODO(bchu): Uncomment when API field name change is in prod.
         }
         tomogramVoxelSpacing {
           id

--- a/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
@@ -174,7 +174,7 @@ function getTomogramDrawerTestMetadata(
     authors: tomogram.authors!.edges!.map((edge) => edge.node!.name),
     publications: '--',
     relatedDatabases: '--',
-    depositionName: tomogram.deposition?.depositionTitle ?? '--',
+    depositionName: '--',
     depositionId: tomogram.deposition?.id ?? '--',
     depositionDate: tomogram.deposition?.depositionDate ?? '--',
     releaseDate: '--',

--- a/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/metadataDrawer/utils.ts
@@ -174,6 +174,8 @@ function getTomogramDrawerTestMetadata(
     authors: tomogram.authors!.edges!.map((edge) => edge.node!.name),
     publications: '--',
     relatedDatabases: '--',
+    // TODO(bchu): Uncomment when API name change is in prod.
+    // depositionName: tomogram.deposition?.title ?? '--',
     depositionName: '--',
     depositionId: tomogram.deposition?.id ?? '--',
     depositionDate: tomogram.deposition?.depositionDate ?? '--',


### PR DESCRIPTION
The field name has changed to `title`. Don't query `title` yet because that change has not made it into APIv2 prod.