### PR TITLE
fix: tomogram table alignment

### DIFF
--- a/frontend/packages/data-portal/app/components/TablePageLayout.tsx
+++ b/frontend/packages/data-portal/app/components/TablePageLayout.tsx
@@ -169,11 +169,15 @@ function TablePageTabContent({
 
         <div
           className={cns(
-            'flex flex-col flex-auto screen-2040:items-center',
+            'flex flex-col flex-auto',
             'pb-sds-xxl',
             'border-t border-sds-color-primitive-gray-300',
             'overflow-x-scroll max-w-full',
             !banner && 'pt-sds-xl',
+
+            filterPanel
+              ? 'screen-2040:items-center'
+              : 'screen-1024:items-center',
           )}
         >
           <div


### PR DESCRIPTION
Fixes alignment issue with tomogram table

## Demo

### Before

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/20991646-c09c-41fa-8f33-990513ebac1b">

### After

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/68822e52-87a6-4afc-973b-5944ed19d751">
