### PR TITLE
docs: Add custom examples to object docstrings

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -258,7 +258,7 @@ class Model:
 
         Expressions with python-native operators (``==``, ``!=``, ``>``, ``>=``, ``<``, ``<=``) must be in the format:
 
-            ``ModelSubclass.field`` ``{operator}`` ``{value}``
+        ``ModelSubclass.field`` ``{operator}`` ``{value}``
 
         Example:
 
@@ -266,7 +266,7 @@ class Model:
 
         Expressions with method operators (``like``, ``ilike``, ``_in``) must be in the format:
 
-            ``ModelSubclass.field.{operator}({value})``
+        ``ModelSubclass.field.{operator}({value})``
 
         Examples:
 
@@ -282,7 +282,7 @@ class Model:
         Values may be strings or numbers depending on the type of the field being matched, and `_in` supports a list of values of the field's corresponding type.
 
         ``ModelSubclass.field`` may be an arbitrarily nested path to any field on any related model, such as:
-            ``ModelSubclass.related_class_field.related_field.second_related_class_field.second_field``
+        ``ModelSubclass.related_class_field.related_field.second_related_class_field.second_field``
 
         Args:
             client:
@@ -292,17 +292,6 @@ class Model:
 
         Yields:
             Matching Model objects.
-
-        Examples:
-
-            Filter runs by attributes, including attributes in related models:
-
-            >>> runs = Run.find(client, query_filters=[Run.name == "TS_026", Run.dataset.id == 10000])
-            >>> runs = Run.find(client, query_filters=[Run.name._in(['TS_026', 'TS_027']), Run.tomogram_voxel_spacings.annotations.object_name.ilike('%membrane%')])
-
-            Get all results for this type:
-
-            >>> runs = Run.find(client)
         """
         filters = {}
         if query_filters:
@@ -322,12 +311,6 @@ class Model:
 
         Returns:
             A matching Model object if found, None otherwise.
-
-        Examples:
-            Get a Run by ID:
-
-            >>> run = Run.get_by_id(client, 1)
-                print(run.name)
         """
         results = cls.find(client, [cls.id == id])
         for result in results:

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
@@ -118,7 +118,9 @@ class Alignment(Model):
         """
         super(Alignment, cls).get_by_id(**kwargs)
 
-    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    get_by_id.__func__.__doc__ = (
+        Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    )
 
 class Annotation(Model):
     """Metadata for an annotation
@@ -260,7 +262,9 @@ class Annotation(Model):
         """
         super(Annotation, cls).get_by_id(**kwargs)
 
-    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    get_by_id.__func__.__doc__ = (
+        Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    )
 
 
 class AnnotationAuthor(Model):
@@ -325,7 +329,9 @@ class AnnotationAuthor(Model):
         """
         super(AnnotationAuthor, cls).get_by_id(**kwargs)
 
-    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    get_by_id.__func__.__doc__ = (
+        Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+    )
 
 
 class AnnotationFile(Model):

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
@@ -122,6 +122,7 @@ class Alignment(Model):
         Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
     )
 
+
 class Annotation(Model):
     """Metadata for an annotation
 

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
@@ -90,6 +90,35 @@ class Alignment(Model):
     https_alignment_metadata: str = StringField()
     is_portal_standard: bool = BooleanField()
 
+    @classmethod
+    def find(cls, **kwargs):
+        """
+        Examples:
+            Filter alignments by attributes, including attributes in related models:
+
+            >>> alignments = Alignment.find(client, query_filters=[Alignment.name == "TS_026", Alignment.dataset.id == 10000])
+            >>> alignments = Alignment.find(client, query_filters=[Alignment.name._in(['TS_026', 'TS_027']), Alignment.tomogram_voxel_spacings.annotations.object_name.ilike('%membrane%')])
+
+            Get all results for this type:
+
+            >>> alignments = Alignment.find(client)
+        """
+        super(Alignment, cls).find(**kwargs)
+
+    find.__func__.__doc__ = Model.find.__func__.__doc__ + find.__func__.__doc__
+
+    @classmethod
+    def get_by_id(cls, **kwargs):
+        """
+        Examples:
+            Get an Alignment by ID:
+
+            >>> alignment = Alignment.get_by_id(client, 1)
+                print(alignment).name)
+        """
+        super(Alignment, cls).get_by_id(**kwargs)
+
+    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
 
 class Annotation(Model):
     """Metadata for an annotation
@@ -203,6 +232,36 @@ class Annotation(Model):
         if download_metadata:
             self.download_metadata(dest_path)
 
+    @classmethod
+    def find(cls, **kwargs):
+        """
+        Examples:
+            Filter annotations by attributes, including attributes in related models:
+
+            >>> annotations = Annotation.find(client, query_filters=[Annotation.name == "TS_026", Annotation.dataset.id == 10000])
+            >>> annotations = Annotation.find(client, query_filters=[Annotation.name._in(['TS_026', 'TS_027']), Annotation.tomogram_voxel_spacings.annotations.object_name.ilike('%membrane%')])
+
+            Get all results for this type:
+
+            >>> annotations = Annotation.find(client)
+        """
+        super(Annotation, cls).find(**kwargs)
+
+    find.__func__.__doc__ = Model.find.__func__.__doc__ + find.__func__.__doc__
+
+    @classmethod
+    def get_by_id(cls, **kwargs):
+        """
+        Examples:
+            Get an Annotation by ID:
+
+            >>> annotation = Annotation.get_by_id(client, 1)
+                print(annotation).name)
+        """
+        super(Annotation, cls).get_by_id(**kwargs)
+
+    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
+
 
 class AnnotationAuthor(Model):
     """Metadata for an annotation's authors
@@ -237,6 +296,36 @@ class AnnotationAuthor(Model):
     affiliation_identifier: str = StringField()
     corresponding_author_status: bool = BooleanField()
     primary_author_status: bool = BooleanField()
+
+    @classmethod
+    def find(cls, **kwargs):
+        """
+        Examples:
+            Filter annotation authors by attributes, including attributes in related models:
+
+            >>> annotation_authors = AnnotationAuthor.find(client, query_filters=[AnnotationAuthor.name == "TS_026", AnnotationAuthor.dataset.id == 10000])
+            >>> annotation_authors = AnnotationAuthor.find(client, query_filters=[Annotation.name._in(['TS_026', 'TS_027']), AnnotationAuthor.tomogram_voxel_spacings.annotations.object_name.ilike('%membrane%')])
+
+            Get all results for this type:
+
+            >>> annotation_author = AnnotationAuthor.find(client)
+        """
+        super(AnnotationAuthor, cls).find(**kwargs)
+
+    find.__func__.__doc__ = Model.find.__func__.__doc__ + find.__func__.__doc__
+
+    @classmethod
+    def get_by_id(cls, **kwargs):
+        """
+        Examples:
+            Get an AnnotationAuthor by ID:
+
+            >>> annotation_author = AnnotationAuthor.get_by_id(client, 1)
+                print(annotation_author).name)
+        """
+        super(AnnotationAuthor, cls).get_by_id(**kwargs)
+
+    get_by_id.__func__.__doc__ = Model.get_by_id.__func__.__doc__ + get_by_id.__func__.__doc__
 
 
 class AnnotationFile(Model):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,10 @@ autodoc_default_options = {
     "exclude-members": "__init__",
 }
 autodoc_typehints = "none"
+autodoc_class_signature = "separated"
 autoclass_content = "both"
+#autodoc_inherit_docstrings = True
+
 tiledb_version = "latest"
 
 intersphinx_mapping = {
@@ -46,7 +49,6 @@ intersphinx_mapping = {
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
-autodoc_class_signature = "separated"
 
 source_suffix = [".rst", ".md"]
 


### PR DESCRIPTION
Adds a proof of concept implementation of custom examples for inherited class method docstrings.

For now, this only implements the custom examples for the Alignment, Annotation and AnnotationAuthor classes. If the approach is accepted I can replicate for the other objects.

Please see the deployed preview here: https://melissawm.github.io/cryoet-data-portal/python-api.html

I only changes the examples to read the specific class name instead of Run, so these examples will most likely need to be updated for text.

