### PR TITLE
fix: Handling datetime in client to_dict()

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -213,19 +213,20 @@ class Model:
             value = getattr(self, k).convert(kwargs.get(strcase.to_lower_camel(k)))
             setattr(self, k, value)
 
-    def _serialize(self, value):
-        if isinstance(value, (datetime, date)):
-            return value.isoformat()
-        return value
-
     def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary representation of this object's attributes"""
         return {k: getattr(self, k) for k in self._get_scalar_fields()}
 
+    def _serialize_datetime(self, value):
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        raise TypeError("Unknown type")
+
     def print_json(self) -> None:
         """Prints a JSON representation of this object's scalar attributes"""
-        obj = {key: self._serialize(val) for key, val in self.to_dict().items()}
-        logging.info(json.dumps(obj, indent=2))
+        logging.info(
+            json.dumps(self.to_dict(), indent=2, default=self._serialize_datetime),
+        )
 
     @classmethod
     @functools.lru_cache(maxsize=32)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -218,7 +218,11 @@ class Model:
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary representation of this object's attributes"""
-        return {k: self._serialize(getattr(self, k)) for k in self._get_scalar_fields()}
+        return {k: getattr(self, k) for k in self._get_scalar_fields()}
+
+    def to_json_dict(self) -> Dict[str, Any]:
+        """Return a JSON encoder friendly representation of this object's attributes"""
+        return {key: self._serialize(val) for key, val in self.to_dict().items()}
 
     @classmethod
     @functools.lru_cache(maxsize=32)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -1,4 +1,6 @@
 import functools
+import json
+import logging
 from datetime import date, datetime
 from importlib import import_module
 from typing import Any, Dict, Iterable, Optional
@@ -220,9 +222,10 @@ class Model:
         """Return a dictionary representation of this object's attributes"""
         return {k: getattr(self, k) for k in self._get_scalar_fields()}
 
-    def to_json_dict(self) -> Dict[str, Any]:
-        """Return a JSON encoder friendly representation of this object's attributes"""
-        return {key: self._serialize(val) for key, val in self.to_dict().items()}
+    def print_json(self) -> None:
+        """Prints a JSON representation of this object's scalar attributes"""
+        obj = {key: self._serialize(val) for key, val in self.to_dict().items()}
+        logging.info(json.dumps(obj, indent=2))
 
     @classmethod
     @functools.lru_cache(maxsize=32)

--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_gql_base.py
@@ -1,5 +1,5 @@
 import functools
-from datetime import datetime
+from datetime import date, datetime
 from importlib import import_module
 from typing import Any, Dict, Iterable, Optional
 
@@ -211,9 +211,14 @@ class Model:
             value = getattr(self, k).convert(kwargs.get(strcase.to_lower_camel(k)))
             setattr(self, k, value)
 
+    def _serialize(self, value):
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        return value
+
     def to_dict(self) -> Dict[str, Any]:
         """Return a dictionary representation of this object's attributes"""
-        return {k: getattr(self, k) for k in self._get_scalar_fields()}
+        return {k: self._serialize(getattr(self, k)) for k in self._get_scalar_fields()}
 
     @classmethod
     @functools.lru_cache(maxsize=32)

--- a/docs/cryoet_data_portal_docsite_quick_start.md
+++ b/docs/cryoet_data_portal_docsite_quick_start.md
@@ -156,7 +156,7 @@ for tomo in tomos:
     print(tomo.name)
 
     # Print the tomogram metadata as a json string
-    print(json.dumps(tomo.to_dict(), indent=4))
+    print(json.dumps(tomo.to_json_dict(), indent=4))
 
     # Download a tomogram in the MRC format (uncomment to actually download files)
     # tomo.download_mrcfile()

--- a/docs/cryoet_data_portal_docsite_quick_start.md
+++ b/docs/cryoet_data_portal_docsite_quick_start.md
@@ -156,7 +156,7 @@ for tomo in tomos:
     print(tomo.name)
 
     # Print the tomogram metadata as a json string
-    print(json.dumps(tomo.to_json_dict(), indent=4))
+    tomo.print_json()
 
     # Download a tomogram in the MRC format (uncomment to actually download files)
     # tomo.download_mrcfile()


### PR DESCRIPTION


Calling `to_dict()` method raises serialization errors for objects that have a date time object. Ex: Dataset, Tomogram,.. 

This fix serializes the date time into the iso_format string.