### PR TITLE
feat: order datasets by release date

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDatasets.server.ts
@@ -12,13 +12,13 @@ const GET_DATASETS_DATA_QUERY = gql(`
   query GetDatasetsData(
     $limit: Int,
     $offset: Int,
-    $order_by_dataset: order_by,
+    $order_by: datasets_order_by!,
     $filter: datasets_bool_exp,
   ) {
     datasets(
       limit: $limit,
       offset: $offset,
-      order_by: { title: $order_by_dataset },
+      order_by: [$order_by],
       where: $filter
     ) {
       id
@@ -382,7 +382,13 @@ export async function getBrowseDatasets({
       filter: getFilter(getFilterState(params), query),
       limit: MAX_PER_PAGE,
       offset: (page - 1) * MAX_PER_PAGE,
-      order_by_dataset: orderBy,
+
+      // Order by dataset title if orderBy is set, otherwise order by release date
+      order_by: orderBy
+        ? { title: orderBy }
+        : {
+            release_date: Order_By.Desc,
+          },
     },
   })
 


### PR DESCRIPTION
Orders datasets on the `/browse-data/datasets` page by release date as the default sort