### PR TITLE
fix: Modifier (cmd, shift, ctrl) clicking on `BaseLink` Links modifies current page view & url 

### DIFF
--- a/frontend/packages/data-portal/app/components/Link/Link.tsx
+++ b/frontend/packages/data-portal/app/components/Link/Link.tsx
@@ -36,10 +36,25 @@ function BaseLink(
     }
   }
 
+  // Handle modifier clicks and prevent default behavior
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    // cmd, ctrl, shift, or middle click
+    const isModifierClick =
+      event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1
+
+    if (isModifierClick) {
+      event.preventDefault()
+      event.stopPropagation()
+      event.nativeEvent.stopImmediatePropagation()
+      window.open(event.currentTarget.href, '_blank', 'noopener,noreferrer')
+    }
+  }
+
   return (
     <RemixLink
       ref={ref}
       to={url}
+      onClick={handleClick}
       className={cnsNoMerge(
         variant === 'dashed-bordered' && DASHED_BORDERED_CLASSES,
         variant === 'dashed-underlined' && DASHED_UNDERLINED_CLASSES,


### PR DESCRIPTION
This fix intercepts the click event and stops event propagation on the current tab (what causes the view to change). Covers all bases with event propagation (both native and synthetic events). 