### PR TITLE
fix: Use correct fieldname in Alignment-TiltSeries relationships.

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_models.py
@@ -70,7 +70,7 @@ class Alignment(Model):
     )
     deposition: Deposition = ItemRelationship("Deposition", "deposition_id", "id")
     deposition_id: int = IntField()
-    tiltseries: TiltSeries = ItemRelationship("TiltSeries", "tilt_series_id", "id")
+    tiltseries: TiltSeries = ItemRelationship("TiltSeries", "tiltseries_id", "id")
     tiltseries_id: int = IntField()
     tomograms: List[Tomogram] = ListRelationship("Tomogram", "id", "alignment_id")
     run: Run = ItemRelationship("Run", "run_id", "id")
@@ -804,7 +804,7 @@ class TiltSeries(Model):
     _gql_root_field: str = "tiltseries"
 
     id: int = IntField()
-    alignments: List[Alignment] = ListRelationship("Alignment", "id", "tilt_series_id")
+    alignments: List[Alignment] = ListRelationship("Alignment", "id", "tiltseries_id")
     run: Run = ItemRelationship("Run", "run_id", "id")
     run_id: int = IntField()
     deposition: Deposition = ItemRelationship("Deposition", "deposition_id", "id")


### PR DESCRIPTION
The `Alignment` model was using source field `tilt_series_id` instead of `tiltseries_id`, the `TiltSeries` model was using `tilt_series_id` instead of `tiltseries_id` as a dest field. 

This PR updates both relationships in the python API client. 

closes #1342 