### PR TITLE
feat: api migration for browse all depositions page

### DIFF
--- a/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV1.ts
+++ b/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV1.ts
@@ -1,0 +1,68 @@
+import { GetDepositionsDataQuery } from 'app/__generated__/graphql'
+import { AuthorInfoType } from 'app/types/authorInfo'
+import {
+  BrowseAllDepositionsPageDataType,
+  Deposition,
+} from 'app/types/PageData/browseAllDepositionsPageData'
+import { ObjectShapeType } from 'app/types/shapeTypes'
+import { remapAPI } from 'app/utils/apiMigration'
+
+const remapV1Author = remapAPI<
+  GetDepositionsDataQuery['depositions'][number]['authors'][number],
+  AuthorInfoType
+>({
+  name: 'name',
+  primaryAuthorStatus: 'primary_author_status',
+  correspondingAuthorStatus: 'corresponding_author_status',
+} as const)
+
+const remapV1Deposition = remapAPI<
+  GetDepositionsDataQuery['depositions'][number],
+  Deposition
+>({
+  id: 'id',
+  title: 'title',
+  keyPhotoThumbnailUrl: 'key_photo_thumbnail_url',
+  depositionDate: 'deposition_date',
+  authors: (deposition) => deposition.authors.map(remapV1Author),
+  annotationCount: (deposition) =>
+    deposition.annotations_aggregate.aggregate?.count ?? 0,
+  annotatedObjects: (deposition) =>
+    Array.from(
+      new Set(
+        deposition.annotations.map((annotation) => annotation.object_name),
+      ),
+    ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+  objectShapeTypes: (deposition) =>
+    Array.from(
+      new Set(
+        deposition.shape_types.flatMap((annotation) =>
+          annotation.files.map((file) => file.shape_type as ObjectShapeType),
+        ),
+      ),
+    ).sort((a, b) => a.localeCompare(b)),
+  acrossDatasets: () => 0,
+} as const)
+
+export const remapV1BrowseAllDepositions = remapAPI<
+  GetDepositionsDataQuery,
+  BrowseAllDepositionsPageDataType
+>({
+  totalDepositionCount: (data) =>
+    data.depositions_aggregate.aggregate?.count ?? 0,
+  filteredDepositionCount: (data) =>
+    data.filtered_depositions_aggregate.aggregate?.count ?? 0,
+  depositions: (data) => data.depositions.map(remapV1Deposition),
+  allObjectNames: (data) =>
+    Array.from(
+      new Set(data.object_names.map((annotation) => annotation.object_name)),
+    ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+  allObjectShapeTypes: (data) =>
+    Array.from(
+      new Set(
+        data.object_shape_types.map(
+          (annotation) => annotation.shape_type as ObjectShapeType,
+        ),
+      ),
+    ).sort((a, b) => a.localeCompare(b)),
+} as const)

--- a/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
+++ b/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
@@ -26,17 +26,19 @@ const remapV2Deposition = remapAPI<
           .filter((value) => value !== '') ?? [],
       ),
     ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
-  objectShapeTypes: (deposition) =>
-    Array.from(
-      new Set(
-        deposition.shapeTypes?.edges.flatMap(
-          (edge) =>
-            edge.node.annotationShapes?.edges.flatMap(
-              (edge2) => edge2.node?.shapeType as ObjectShapeType,
-            ),
-        ),
-      ),
-    ).sort((a, b) => a.localeCompare(b)),
+  // TODO: uncomment/remap when efficient query is available
+  // objectShapeTypes: (deposition) =>
+  //   Array.from(
+  //     new Set(
+  //       deposition.shapeTypes?.edges.flatMap(
+  //         (edge) =>
+  //           edge.node.annotationShapes?.edges.flatMap(
+  //             (edge2) => edge2.node?.shapeType as ObjectShapeType,
+  //           ),
+  //       ),
+  //     ),
+  //   ).sort((a, b) => a.localeCompare(b)),
+  objectShapeTypes: () => [],
   acrossDatasets: (deposition) =>
     deposition.annotationDatasetCount?.aggregate?.length ?? 0,
 } as const)

--- a/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
+++ b/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
@@ -1,0 +1,76 @@
+import { GetDepositionsDataV2Query } from 'app/__generated_v2__/graphql'
+import {
+  BrowseAllDepositionsPageDataType,
+  Deposition,
+} from 'app/types/PageData/browseAllDepositionsPageData'
+import { ObjectShapeType } from 'app/types/shapeTypes'
+import { remapAPI } from 'app/utils/apiMigration'
+
+const remapV2Deposition = remapAPI<
+  GetDepositionsDataV2Query['depositions'][number],
+  Deposition
+>({
+  id: 'id',
+  title: 'title',
+  keyPhotoThumbnailUrl: 'keyPhotoThumbnailUrl',
+  depositionDate: (deposition) => deposition.depositionDate.split('T')[0],
+  authors: (deposition) =>
+    deposition.authors?.edges?.map((edge) => edge.node) ?? [],
+  annotationCount: (deposition) =>
+    deposition.annotationsCount?.aggregate?.at(0)?.count ?? 0,
+  annotatedObjects: (deposition) =>
+    Array.from(
+      new Set(
+        deposition.objectNames?.aggregate
+          ?.map((aggregate) => aggregate.groupBy?.objectName ?? '')
+          .filter((value) => value !== '') ?? [],
+      ),
+    ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+  objectShapeTypes: (deposition) =>
+    Array.from(
+      new Set(
+        deposition.shapeTypes?.edges.flatMap(
+          (edge) =>
+            edge.node.annotationShapes?.edges.flatMap(
+              (edge2) => edge2.node?.shapeType as ObjectShapeType,
+            ),
+        ),
+      ),
+    ).sort((a, b) => a.localeCompare(b)),
+  acrossDatasets: (deposition) =>
+    deposition.annotationDatasetCount?.aggregate?.length ?? 0,
+} as const)
+
+export const remapV2BrowseAllDepositions = remapAPI<
+  GetDepositionsDataV2Query,
+  BrowseAllDepositionsPageDataType
+>({
+  totalDepositionCount: (data) =>
+    data.totalDepositionCount?.aggregate?.at(0)?.count ?? 0,
+  filteredDepositionCount: (data) =>
+    data.filteredDepositionCount?.aggregate?.at(0)?.count ?? 0,
+  depositions: (data) =>
+    data.depositions.map(remapV2Deposition).sort((a, b) => {
+      const dateDiff =
+        new Date(b.depositionDate).getTime() -
+        new Date(a.depositionDate).getTime()
+      if (dateDiff !== 0) return dateDiff
+      return b.id - a.id
+    }),
+  allObjectNames: (data) =>
+    Array.from(
+      new Set(
+        data.allObjectNames?.aggregate
+          ?.map((aggregate) => aggregate.groupBy?.objectName ?? '')
+          .filter((value) => value !== '') ?? [],
+      ),
+    ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+  allObjectShapeTypes: (data) =>
+    Array.from(
+      new Set(
+        data.allObjectShapeTypes?.aggregate?.map(
+          (aggregate) => aggregate.groupBy?.shapeType as ObjectShapeType,
+        ) ?? [],
+      ),
+    ).sort((a, b) => a.localeCompare(b)),
+} as const)

--- a/frontend/packages/data-portal/app/apiNormalization/index.ts
+++ b/frontend/packages/data-portal/app/apiNormalization/index.ts
@@ -1,0 +1,2 @@
+export * from './browseAllDepositionsV1'
+export * from './browseAllDepositionsV2'

--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositions.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositions.server.ts
@@ -19,7 +19,7 @@ const GET_DEPOSITIONS_DATA_QUERY = gql(`
     depositions(
       limit: $limit,
       offset: $offset,
-      order_by: { deposition_date: $order_by_deposition },
+      order_by: { deposition_date: $order_by_deposition, id: desc },
       where: $filter
     ) {
       id

--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
@@ -54,19 +54,19 @@ const GET_DEPOSITIONS_DATA_QUERY = gql(`
       }
 
       ## TODO: find how to get distinct shape types – as-is increases load time by ~2000ms (3x slower compared to v1)
-      shapeTypes: annotations {
-        edges {
-          node {
-            annotationShapes {
-              edges {
-                node {
-                  shapeType
-                }
-              }
-            }
-          }
-        }
-      }
+      # shapeTypes: annotations {
+      #   edges {
+      #     node {
+      #       annotationShapes {
+      #         edges {
+      #           node {
+      #             shapeType
+      #           }
+      #         }
+      #       }
+      #     }
+      #   }
+      # }
 
       annotationDatasetCount: annotationsAggregate {
         aggregate {

--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
@@ -1,0 +1,142 @@
+import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { performance } from 'perf_hooks'
+
+import { gql } from 'app/__generated_v2__'
+import { OrderBy } from 'app/__generated_v2__/graphql'
+import { MAX_PER_PAGE } from 'app/constants/pagination'
+
+const GET_DEPOSITIONS_DATA_QUERY = gql(`
+  query GetDepositionsDataV2(
+    $limit: Int,
+    $offset: Int,
+    $orderByDeposition: orderBy,
+  ) {
+    depositions(
+      limitOffset: {
+        limit: $limit,
+        offset: $offset,
+      },
+      orderBy: { depositionDate: $orderByDeposition, id: desc },
+      where: {depositionTypes: {type: {_eq: annotation}}}
+    ) {
+      id
+      title
+      keyPhotoThumbnailUrl
+      depositionDate
+
+      authors(
+        orderBy: {
+          authorListOrder: asc,
+        },
+      ) {
+        edges {
+          node {
+            name
+            primaryAuthorStatus
+            correspondingAuthorStatus
+          }
+        }
+      }
+
+      annotationsCount: annotationsAggregate {
+        aggregate {
+          count
+        }
+      }
+
+      objectNames: annotationsAggregate {
+        aggregate {
+          groupBy {
+            objectName
+          }
+          count
+        }
+      }
+
+      ## TODO: find how to get distinct shape types – as-is increases load time by ~2000ms (3x slower compared to v1)
+      shapeTypes: annotations {
+        edges {
+          node {
+            annotationShapes {
+              edges {
+                node {
+                  shapeType
+                }
+              }
+            }
+          }
+        }
+      }
+
+      annotationDatasetCount: annotationsAggregate {
+        aggregate {
+          groupBy {
+            run {
+              dataset {
+                id
+              }
+            }
+          }
+          count
+        }
+      }
+    }
+
+    totalDepositionCount: depositionsAggregate(where: {depositionTypes: {type: {_eq: annotation}}}) {
+      aggregate {
+        count
+      }
+    }
+
+    filteredDepositionCount: depositionsAggregate(where: {depositionTypes: {type: {_eq: annotation}}}) {
+      aggregate {
+        count
+      }
+    }
+
+    allObjectNames: annotationsAggregate {
+      aggregate {
+        groupBy {
+          objectName
+        }
+        count
+      }
+    }
+
+    allObjectShapeTypes: annotationShapesAggregate {
+      aggregate {
+        groupBy {
+          shapeType
+        }
+        count
+      }
+    }
+  }
+`)
+
+export async function getBrowseDepositionsV2({
+  client,
+  orderBy,
+  page = 1,
+}: {
+  client: ApolloClient<NormalizedCacheObject>
+  orderBy?: OrderBy | null
+  page?: number
+}) {
+  const start = performance.now()
+
+  const results = await client.query({
+    query: GET_DEPOSITIONS_DATA_QUERY,
+    variables: {
+      limit: MAX_PER_PAGE,
+      offset: (page - 1) * MAX_PER_PAGE,
+      orderByDeposition: orderBy ?? OrderBy.Desc,
+    },
+  })
+
+  const end = performance.now()
+  // eslint-disable-next-line no-console
+  console.log(`getBrowseDepositionsV2 query perf: ${end - start}ms`)
+
+  return results
+}

--- a/frontend/packages/data-portal/app/hooks/useDepositions.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositions.ts
@@ -1,4 +1,3 @@
-import { detailedDiff } from 'deep-object-diff'
 import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
@@ -8,6 +7,8 @@ import {
   remapV1BrowseAllDepositions,
   remapV2BrowseAllDepositions,
 } from 'app/apiNormalization'
+import { BrowseAllDepositionsPageDataType } from 'app/types/PageData/browseAllDepositionsPageData'
+import { pickAPISource } from 'app/utils/apiMigration'
 
 export function useDepositions() {
   const { v1, v2 } = useTypedLoaderData<{
@@ -18,8 +19,30 @@ export function useDepositions() {
   const v1result = useMemo(() => remapV1BrowseAllDepositions(v1), [v1])
   const v2result = useMemo(() => remapV2BrowseAllDepositions(v2), [v2])
 
-  // eslint-disable-next-line no-console
-  console.log(detailedDiff(v1result.depositions, v2result.depositions))
+  const combined = useMemo(
+    () =>
+      pickAPISource<BrowseAllDepositionsPageDataType>(
+        { v1: v1result, v2: v2result },
+        {
+          allObjectNames: 'v2',
+          allObjectShapeTypes: 'v2',
+          filteredDepositionCount: 'v2',
+          totalDepositionCount: 'v2',
+          depositions: {
+            acrossDatasets: 'v2',
+            annotationCount: 'v2',
+            annotatedObjects: 'v2',
+            authors: 'v2',
+            depositionDate: 'v2',
+            id: 'v2',
+            keyPhotoThumbnailUrl: 'v2',
+            objectShapeTypes: 'v1',
+            title: 'v2',
+          },
+        },
+      ),
+    [v1result, v2result],
+  )
 
-  return v2result
+  return combined
 }

--- a/frontend/packages/data-portal/app/types/PageData/browseAllDepositionsPageData.ts
+++ b/frontend/packages/data-portal/app/types/PageData/browseAllDepositionsPageData.ts
@@ -1,0 +1,22 @@
+import { AuthorInfoType } from 'app/types/authorInfo'
+import { ObjectShapeType } from 'app/types/shapeTypes'
+
+export type BrowseAllDepositionsPageDataType = {
+  totalDepositionCount: number
+  filteredDepositionCount: number
+  depositions: Deposition[]
+  allObjectNames: string[]
+  allObjectShapeTypes: ObjectShapeType[]
+}
+
+export type Deposition = {
+  id: number
+  title: string
+  authors: AuthorInfoType[]
+  keyPhotoThumbnailUrl?: string
+  depositionDate: string
+  annotationCount: number
+  acrossDatasets: number
+  annotatedObjects: string[]
+  objectShapeTypes: ObjectShapeType[]
+}

--- a/frontend/packages/data-portal/app/types/authorInfo.ts
+++ b/frontend/packages/data-portal/app/types/authorInfo.ts
@@ -1,0 +1,7 @@
+export type AuthorInfoType = {
+  correspondingAuthorStatus?: boolean | null
+  email?: string | null
+  name: string
+  orcid?: string | null
+  primaryAuthorStatus?: boolean | null
+}

--- a/frontend/packages/data-portal/e2e/apiLoaders/browseAllDepositions.ts
+++ b/frontend/packages/data-portal/e2e/apiLoaders/browseAllDepositions.ts
@@ -1,0 +1,37 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+
+import { Order_By } from 'app/__generated__/graphql'
+import { OrderBy } from 'app/__generated_v2__/graphql'
+import {
+  remapV1BrowseAllDepositions,
+  remapV2BrowseAllDepositions,
+} from 'app/apiNormalization'
+import { getBrowseDepositions } from 'app/graphql/getBrowseDepositions.server'
+import { getBrowseDepositionsV2 } from 'app/graphql/getBrowseDepositionsV2.server'
+
+export async function loadDepositionsV1Data(
+  client: ApolloClient<NormalizedCacheObject>,
+  page: number,
+) {
+  const { data } = await getBrowseDepositions({
+    client,
+    orderBy: Order_By.Desc,
+    page,
+    query: '',
+  })
+
+  return remapV1BrowseAllDepositions(data)
+}
+
+export async function loadDepositionsV2Data(
+  client: ApolloClient<NormalizedCacheObject>,
+  page: number,
+) {
+  const { data } = await getBrowseDepositionsV2({
+    client,
+    orderBy: OrderBy.Desc,
+    page,
+  })
+
+  return remapV2BrowseAllDepositions(data)
+}

--- a/frontend/packages/data-portal/e2e/apiMigration.test.ts
+++ b/frontend/packages/data-portal/e2e/apiMigration.test.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import { expect, test } from '@playwright/test'
-import { detailedDiff } from 'deep-object-diff'
+import { updatedDiff } from 'deep-object-diff'
 import {
   loadDepositionsV1Data,
   loadDepositionsV2Data,
@@ -21,21 +21,19 @@ test.describe('API Migration Parity Check', () => {
       const v1 = await loadDepositionsV1Data(client, 1)
       const v2 = await loadDepositionsV2Data(clientV2, 1)
 
-      expect(detailedDiff(v1, v2)).toEqual({
-        added: {},
-        deleted: {},
-        updated: {
-          depositions: v2.depositions.reduce(
-            (acc, v2Deposition, index) => ({
-              ...acc,
-              [index]: {
-                // `acrossDatasets` field is only available in V2 so V1 sets it to 0
-                acrossDatasets: v2Deposition.acrossDatasets,
-              },
-            }),
-            {},
-          ),
-        },
+      expect(updatedDiff(v1, v2)).toEqual({
+        depositions: v2.depositions.reduce(
+          (acc, v2Deposition, index) => ({
+            ...acc,
+            [index]: {
+              // `acrossDatasets` field is only available in V2 so V1 sets it to 0
+              acrossDatasets: v2Deposition.acrossDatasets,
+              // `objectShapeTypes` is inefficient to fetch in V2
+              objectShapeTypes: {}, // we use {} instead of [] here because the differ interprets an empty array as an object
+            },
+          }),
+          {},
+        ),
       })
     })
   })

--- a/frontend/packages/data-portal/e2e/apiMigration.test.ts
+++ b/frontend/packages/data-portal/e2e/apiMigration.test.ts
@@ -1,0 +1,42 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { expect, test } from '@playwright/test'
+import { detailedDiff } from 'deep-object-diff'
+import {
+  loadDepositionsV1Data,
+  loadDepositionsV2Data,
+} from 'e2e/apiLoaders/browseAllDepositions'
+import { getApolloClient, getApolloClientV2 } from 'e2e/apollo'
+
+test.describe('API Migration Parity Check', () => {
+  let client: ApolloClient<NormalizedCacheObject>
+  let clientV2: ApolloClient<NormalizedCacheObject>
+
+  test.beforeEach(() => {
+    client = getApolloClient()
+    clientV2 = getApolloClientV2()
+  })
+
+  test.describe('getBrowseAllDepositionPageData', () => {
+    test('should return the same data for V1 and V2 with the exception of `acrossDatasets` field', async () => {
+      const v1 = await loadDepositionsV1Data(client, 1)
+      const v2 = await loadDepositionsV2Data(clientV2, 1)
+
+      expect(detailedDiff(v1, v2)).toEqual({
+        added: {},
+        deleted: {},
+        updated: {
+          depositions: v2.depositions.reduce(
+            (acc, v2Deposition, index) => ({
+              ...acc,
+              [index]: {
+                // `acrossDatasets` field is only available in V2 so V1 sets it to 0
+                acrossDatasets: v2Deposition.acrossDatasets,
+              },
+            }),
+            {},
+          ),
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
#1229 
#1227

note that there is no way from my current knowledge to get distinct values from `depositions.shapeTypes` in the V2 API which hinders performance so it fetches from V1 instead for ~33% faster load times