### PR TITLE
chore: update survey banner copy

### DIFF
--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -383,7 +383,7 @@
   "stepCount": "Step {{count}} of {{max}}",
   "submitFeedback": "Submit Feedback",
   "submittedByDatasetAuthor": "Submitted by Dataset Author",
-  "surveyBanner": "Share first impressions, or sign up for invites to future feedback activities in <url to='$t(surveyLink)'>this short form</url>.",
+  "surveyBanner": "Share first impressions of the portal, or sign up for invites to future feedback activities in <url to='$t(surveyLink)'>this short form</url>.",
   "surveyLink": "https://airtable.com/apppmytRJXoXYTO9w/shrjmV9knAC7E7VVM?prefill_Event=Banner&hide_Event=true",
   "symbolPeriod": ".",
   "tellUsMore": "Tell us More",


### PR DESCRIPTION
Updates survey banner copy to include `of the portal` in the text

## Demos

### Before

<img width="728" alt="image" src="https://github.com/user-attachments/assets/5545ced7-393b-432b-b79f-2dd8923042f4">

### After

<img width="725" alt="image" src="https://github.com/user-attachments/assets/765a101b-8f4b-4175-9402-41371accd281">

