### PR TITLE
feat: preview label deployments

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -74,10 +74,8 @@ jobs:
         if: |
           github.event_name == 'push' || (
             github.event_name == 'pull_request' && (
-              github.event.action == 'labeled' || (
-                github.event.action == 'synchronize' &&
-                contains(github.event.pull_request.labels.*.name, 'preview')
-              )
+              github.event.action == 'labeled' ||
+              github.event.action == 'synchronize'
             )
           )
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.24.0
@@ -100,10 +98,8 @@ jobs:
         if: |
           github.event_name == 'push' || (
             github.event_name == 'pull_request' && (
-              github.event.action == 'labeled' || (
-                github.event.action == 'synchronize' &&
-                contains(github.event.pull_request.labels.*.name, 'preview')
-              )
+              github.event.action == 'labeled' ||
+              github.event.action == 'synchronize'
             )
           )
         run: |
@@ -179,10 +175,8 @@ jobs:
         if: |
           github.event_name == 'delete' || (
             github.event_name == 'pull_request' && (
-              github.event.action == 'unlabeled' || (
-                github.event.action == 'closed' &&
-                contains(github.event.pull_request.labels.*.name, 'preview')
-              )
+              github.event.action == 'unlabeled' ||
+              github.event.action == 'closed'
             )
           )
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.24.0


### PR DESCRIPTION
Adds the ability to create preview deployments from an existing PR by adding a `preview` label to the PR.  This works by updating the `dev-deploy.yml` so that:

1. Adding the `preview` label creates a new preview deployment and posts a comment on the PR with the URL and last updated date
2. Removing the `preview` label takes down preview deployment and deletes the PR comment
3. Merging or closing the PR will take down the preview deployment and delete the PR comment

## Changes to existing workflow

- Pushes to `dev-*` should still work as expected
- Workflow will no longer throw an error if the title is > 25 characters, instead it'll trim the rest of the characters 

## Demo

### PR comment

<img width="930" alt="image" src="https://github.com/user-attachments/assets/a5263e28-8b2a-4b82-a076-de4c6a8ee430" />

### Create preview on label

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/12418548047

### Delete preview on label

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/12405421842

### Delete preview on close

https://github.com/chanzuckerberg/cryoet-data-portal/actions/runs/12421062766