### PR TITLE
fix: Fix affine transformation matrix diff log

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
@@ -168,10 +168,7 @@ export function logIfHasDiff(
                   alignment: {
                     affineTransformationMatrix: JSON.stringify(
                       tomogram.affine_transformation_matrix,
-                    )
-                      .replaceAll('[', '{')
-                      .replaceAll(']', '}')
-                      .replaceAll(', ', ','),
+                    ).replaceAll(',', ', '),
                   },
                 },
               })),


### PR DESCRIPTION
Turns out the braces format was a BE bug.