### PR TITLE
fix: Never send empty argument objects to APIv2

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
@@ -218,8 +218,6 @@ function getRunFilter(
     datasetId: {
       _eq: datasetId,
     },
-    tiltseries: {},
-    annotations: {},
   }
 
   // Deposition filter:
@@ -234,7 +232,8 @@ function getRunFilter(
   const tiltRangeMin = parseFloat(filterState.tiltSeries.min)
   const tiltRangeMax = parseFloat(filterState.tiltSeries.max)
   if (Number.isFinite(tiltRangeMin) || Number.isFinite(tiltRangeMax)) {
-    where.tiltseries!.tiltRange = {
+    where.tiltseries ??= {}
+    where.tiltseries.tiltRange = {
       _gte: Number.isFinite(tiltRangeMin)
         ? tiltRangeMin
         : DEFAULT_TILT_RANGE_MIN,
@@ -244,7 +243,8 @@ function getRunFilter(
     }
   }
   if (filterState.tiltSeries.qualityScore.length > 0) {
-    where.tiltseries!.tiltSeriesQuality = {
+    where.tiltseries ??= {}
+    where.tiltseries.tiltSeriesQuality = {
       _in: filterState.tiltSeries.qualityScore
         .map(parseInt)
         .filter((val) => Number.isFinite(val)),
@@ -253,15 +253,18 @@ function getRunFilter(
 
   // Annotation filters:
   if (filterState.includedContents.isGroundTruthEnabled) {
-    where.annotations!.groundTruthStatus = { _eq: true }
+    where.annotations ??= {}
+    where.annotations.groundTruthStatus = { _eq: true }
   }
   if (filterState.annotation.objectNames.length > 0) {
-    where.annotations!.objectName = {
+    where.annotations ??= {}
+    where.annotations.objectName = {
       _in: filterState.annotation.objectNames,
     }
   }
   if (filterState.annotation.objectShapeTypes.length > 0) {
-    where.annotations!.annotationShapes = {
+    where.annotations ??= {}
+    where.annotations.annotationShapes = {
       shapeType: {
         _in: filterState.annotation
           .objectShapeTypes as Annotation_File_Shape_Type_Enum[], // TODO(bchu): Remove typecast.
@@ -269,7 +272,8 @@ function getRunFilter(
     }
   }
   if (filterState.annotation.objectId !== null) {
-    where.annotations!.objectId = {
+    where.annotations ??= {}
+    where.annotations.objectId = {
       _ilike: `%${filterState.annotation.objectId.replace(':', '_')}`, // _ is wildcard
     }
   }

--- a/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
@@ -87,9 +87,7 @@ function getFilter(
   filterState: FilterState,
   searchText?: string,
 ): DatasetWhereClause {
-  const where: DatasetWhereClause = {
-    runs: { annotations: {}, tiltseries: {}, tomograms: {} },
-  }
+  const where: DatasetWhereClause = {}
 
   // Search by Dataset Name
   if (searchText) {
@@ -101,7 +99,9 @@ function getFilter(
   // INCLUDED CONTENTS SECTION
   // Ground Truth Annotation
   if (filterState.includedContents.isGroundTruthEnabled) {
-    where.runs!.annotations!.groundTruthStatus = {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.groundTruthStatus = {
       _eq: true,
     }
   }
@@ -201,16 +201,15 @@ function getFilter(
     }
   }
   // Dataset Author
-  if (filterState.author.name || filterState.author.orcid) {
-    where.authors = {}
-  }
   if (filterState.author.name) {
-    where.authors!.name = {
+    where.authors ??= {}
+    where.authors.name = {
       _ilike: `%${filterState.author.name}%`,
     }
   }
   if (filterState.author.orcid) {
-    where.authors!.orcid = {
+    where.authors ??= {}
+    where.authors.orcid = {
       _ilike: `%${filterState.author.orcid}%`,
     }
   }
@@ -235,21 +234,27 @@ function getFilter(
 
   // ANNOTATION METADATA SECTION
   const { objectNames, objectId, objectShapeTypes } = filterState.annotation
+  // Object Name
   if (objectNames.length > 0) {
-    // Object Name
-    where.runs!.annotations!.objectName = {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.objectName = {
       _in: objectNames,
     }
   }
   // Object ID
   if (objectId) {
-    where.runs!.annotations!.objectId = {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.objectId = {
       _eq: objectId,
     }
   }
   // Object Shape Type
   if (objectShapeTypes.length > 0) {
-    where.runs!.annotations!.annotationShapes = {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.annotationShapes = {
       shapeType: {
         _in: objectShapeTypes as Annotation_File_Shape_Type_Enum[], // TODO(bchu): Remove typecast.
       },
@@ -258,7 +263,9 @@ function getFilter(
 
   // HARDWARE SECTION
   if (filterState.hardware.cameraManufacturer) {
-    where.runs!.tiltseries!.cameraManufacturer = {
+    where.runs ??= { tiltseries: {} }
+    where.runs.tiltseries ??= {}
+    where.runs.tiltseries.cameraManufacturer = {
       _eq: filterState.hardware.cameraManufacturer,
     }
   }
@@ -267,7 +274,9 @@ function getFilter(
   const tiltRangeMin = parseFloat(filterState.tiltSeries.min)
   const tiltRangeMax = parseFloat(filterState.tiltSeries.max)
   if (Number.isFinite(tiltRangeMin) || Number.isFinite(tiltRangeMax)) {
-    where.runs!.tiltseries!.tiltRange = {
+    where.runs ??= { tiltseries: {} }
+    where.runs.tiltseries ??= {}
+    where.runs.tiltseries.tiltRange = {
       _gte: Number.isFinite(tiltRangeMin)
         ? tiltRangeMin
         : DEFAULT_TILT_RANGE_MIN,
@@ -280,7 +289,9 @@ function getFilter(
   // TOMOGRAM METADATA SECTION
   // Fiducial Alignment Status
   if (filterState.tomogram.fiducialAlignmentStatus) {
-    where.runs!.tomograms!.fiducialAlignmentStatus = {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.fiducialAlignmentStatus = {
       _eq:
         filterState.tomogram.fiducialAlignmentStatus === 'true'
           ? Fiducial_Alignment_Status_Enum.Fiducial
@@ -289,7 +300,9 @@ function getFilter(
   }
   // Reconstruction Method
   if (filterState.tomogram.reconstructionMethod) {
-    where.runs!.tomograms!.reconstructionMethod = {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.reconstructionMethod = {
       _eq: convertReconstructionMethodToV2(
         filterState.tomogram.reconstructionMethod,
       ),
@@ -297,7 +310,9 @@ function getFilter(
   }
   // Reconstruction Software
   if (filterState.tomogram.reconstructionSoftware) {
-    where.runs!.tomograms!.reconstructionSoftware = {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.reconstructionSoftware = {
       _eq: filterState.tomogram.reconstructionSoftware,
     }
   }

--- a/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
@@ -39,6 +39,8 @@ export function logIfHasDiff(
         methodLinkA.node.link.localeCompare(methodLinkB.node.link),
     )
   }
+  // Tomograms are currently being sorted by the FE.
+  v2.tomograms.sort((tomogramA, tomogramB) => tomogramB.id - tomogramA.id)
   for (const tomogram of v2.tomograms) {
     // Delete fields that don't exist in V1.
     delete tomogram.alignment
@@ -295,50 +297,52 @@ export function logIfHasDiff(
         },
       },
     })),
-    tomograms: v1.tomograms.map((tomogram) => ({
-      ctfCorrected: tomogram.ctf_corrected,
-      fiducialAlignmentStatus:
-        tomogram.fiducial_alignment_status as Fiducial_Alignment_Status_Enum,
-      httpsMrcFile: tomogram.https_mrc_scale0,
-      id: tomogram.id,
-      isPortalStandard: false,
-      isAuthorSubmitted: tomogram.is_canonical,
-      keyPhotoThumbnailUrl: tomogram.key_photo_thumbnail_url,
-      keyPhotoUrl: tomogram.key_photo_url,
-      name: tomogram.name,
-      neuroglancerConfig: tomogram.neuroglancer_config,
-      processing: tomogram.processing as Tomogram_Processing_Enum,
-      processingSoftware: tomogram.processing_software,
-      reconstructionMethod: (tomogram.reconstruction_method ===
-      'Weighted back projection'
-        ? 'WBP'
-        : tomogram.reconstruction_method) as Tomogram_Reconstruction_Method_Enum,
-      reconstructionSoftware: tomogram.reconstruction_software,
-      s3MrcFile: tomogram.s3_mrc_scale0,
-      s3OmezarrDir: tomogram.s3_omezarr_dir,
-      sizeX: tomogram.size_x,
-      sizeY: tomogram.size_y,
-      sizeZ: tomogram.size_z,
-      voxelSpacing: tomogram.voxel_spacing,
-      tomogramVoxelSpacing:
-        tomogram.tomogram_voxel_spacing != null
-          ? {
-              id: tomogram.tomogram_voxel_spacing.id,
-              s3Prefix: tomogram.tomogram_voxel_spacing.s3_prefix!,
-            }
-          : undefined,
-      authors: {
-        edges: tomogram.authors.map((author) => ({
-          node: {
-            primaryAuthorStatus: author.primary_author_status,
-            correspondingAuthorStatus: author.corresponding_author_status,
-            name: author.name,
-            email: author.email,
-            orcid: author.orcid,
-          },
-        })),
-      },
-    })),
+    tomograms: v1.tomograms
+      .map((tomogram) => ({
+        ctfCorrected: tomogram.ctf_corrected,
+        fiducialAlignmentStatus:
+          tomogram.fiducial_alignment_status as Fiducial_Alignment_Status_Enum,
+        httpsMrcFile: tomogram.https_mrc_scale0,
+        id: tomogram.id,
+        isPortalStandard: false,
+        isAuthorSubmitted: tomogram.is_canonical,
+        keyPhotoThumbnailUrl: tomogram.key_photo_thumbnail_url,
+        keyPhotoUrl: tomogram.key_photo_url,
+        name: tomogram.name,
+        neuroglancerConfig: tomogram.neuroglancer_config,
+        processing: tomogram.processing as Tomogram_Processing_Enum,
+        processingSoftware: tomogram.processing_software,
+        reconstructionMethod: (tomogram.reconstruction_method ===
+        'Weighted back projection'
+          ? 'WBP'
+          : tomogram.reconstruction_method) as Tomogram_Reconstruction_Method_Enum,
+        reconstructionSoftware: tomogram.reconstruction_software,
+        s3MrcFile: tomogram.s3_mrc_scale0,
+        s3OmezarrDir: tomogram.s3_omezarr_dir,
+        sizeX: tomogram.size_x,
+        sizeY: tomogram.size_y,
+        sizeZ: tomogram.size_z,
+        voxelSpacing: tomogram.voxel_spacing,
+        tomogramVoxelSpacing:
+          tomogram.tomogram_voxel_spacing != null
+            ? {
+                id: tomogram.tomogram_voxel_spacing.id,
+                s3Prefix: tomogram.tomogram_voxel_spacing.s3_prefix!,
+              }
+            : undefined,
+        authors: {
+          edges: tomogram.authors.map((author) => ({
+            node: {
+              primaryAuthorStatus: author.primary_author_status,
+              correspondingAuthorStatus: author.corresponding_author_status,
+              name: author.name,
+              email: author.email,
+              orcid: author.orcid,
+            },
+          })),
+        },
+      }))
+      .sort((tomogramA, tomogramB) => tomogramB.id - tomogramA.id),
     uniqueAnnotationSoftwares: {
       aggregate: v1.annotations_for_softwares
         .map((annotation) => ({
@@ -443,7 +447,9 @@ export function logIfHasDiff(
     console.log(
       `DIFF AT ${url} ======================================== ${JSON.stringify(
         v1Transformed,
-      )} ======================================== ${JSON.stringify(v2)}`,
+      )} ================================================================================ ${JSON.stringify(
+        v2,
+      )}`,
     )
   }
 }

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -432,7 +432,6 @@ function getAnnotationShapesFilter(
           _eq: runId,
         },
       },
-      authors: {},
     },
   }
 
@@ -459,12 +458,16 @@ function getAnnotationShapesFilter(
   // Author filters
   const { name, orcid } = filterState.author
   if (name) {
-    where.annotation!.authors!.name = {
+    where.annotation ??= { authors: {} }
+    where.annotation.authors ??= {}
+    where.annotation.authors.name = {
       _ilike: `%${name}%`,
     }
   }
   if (orcid) {
-    where.annotation!.authors!.orcid = {
+    where.annotation ??= { authors: {} }
+    where.annotation.authors ??= {}
+    where.annotation.authors.orcid = {
       _ilike: `%${orcid}%`,
     }
   }
@@ -473,29 +476,34 @@ function getAnnotationShapesFilter(
   const { objectNames, annotationSoftwares, methodTypes, objectId } =
     filterState.annotation
   if (objectNames.length > 0) {
-    where.annotation!.objectName = {
+    where.annotation ??= {}
+    where.annotation.objectName = {
       _in: objectNames,
     }
   }
   if (objectId) {
-    where.annotation!.objectId = {
+    where.annotation ??= {}
+    where.annotation.objectId = {
       _ilike: `%${objectId.replace(':', '_')}`, // _ is wildcard
     }
   }
   if (methodTypes.length > 0) {
-    where.annotation!.methodType = {
+    where.annotation ??= {}
+    where.annotation.methodType = {
       _in: methodTypes as Annotation_Method_Type_Enum[],
     }
   }
   if (annotationSoftwares.length > 0) {
-    where.annotation!.annotationSoftware = {
+    where.annotation ??= {}
+    where.annotation.annotationSoftware = {
       _in: annotationSoftwares,
     }
   }
 
   // Ground truth dividers
   if (groundTruthStatus !== undefined) {
-    where.annotation!.groundTruthStatus = {
+    where.annotation ??= {}
+    where.annotation.groundTruthStatus = {
       _eq: groundTruthStatus,
     }
   }


### PR DESCRIPTION
 - Undoes the refactoring that initializes empty objects by default because apparently sending empty argument objects to Platformics does affect query results 🫢 
 - I went with using `??=` to initialize empty objects only when needed. It's a bit more annoying to look at but compared to initializing empty objects in a separate if condition (what I had before) it prevents the need to use non-null assertions everywhere and makes it obvious that the object is being correctly initialized at first glance without having to check that the if conditions align.