### PR TITLE
fix: Fix deposition dropdown filters being broken

### DIFF
--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -105,7 +105,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   return typedjson({
     depositionData: depositionResponse.data,
-    datasetsFilterData: datasetsFilterReponse.data,
+    v1FilterValues: datasetsFilterReponse.data,
     annotationMethodCounts,
   })
 }


### PR DESCRIPTION
Forgot to update the variable name for the deposition page which also uses the filter data query. I only changed the variable name in the hook and in the datasets page loader.