### PR TITLE
fix: Remove non-null assertions in dataset page hook

### DIFF
--- a/frontend/packages/data-portal/app/hooks/useDatasetById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDatasetById.ts
@@ -2,6 +2,7 @@ import { useTypedLoaderData } from 'remix-typedjson'
 
 import { GetDatasetByIdQuery } from 'app/__generated__/graphql'
 import { GetDatasetByIdV2Query } from 'app/__generated_v2__/graphql'
+import { isDefined } from 'app/utils/nullish'
 
 export function useDatasetById() {
   const { v1, v2 } = useTypedLoaderData<{
@@ -13,13 +14,15 @@ export function useDatasetById() {
 
   const deposition = v2.depositions[0]
 
-  const objectNames = v2.annotationsAggregate.aggregate!.map(
-    (aggregate) => aggregate.groupBy!.objectName!,
-  )
+  const objectNames =
+    v2.annotationsAggregate.aggregate
+      ?.map((aggregate) => aggregate.groupBy?.objectName)
+      .filter(isDefined) ?? []
 
-  const objectShapeTypes = v2.annotationShapesAggregate.aggregate!.map(
-    (aggregate) => aggregate.groupBy!.shapeType!,
-  )
+  const objectShapeTypes =
+    v2.annotationShapesAggregate.aggregate
+      ?.map((aggregate) => aggregate.groupBy?.shapeType)
+      .filter(isDefined) ?? []
 
   return {
     dataset,


### PR DESCRIPTION
Since I found out sometimes the `aggregate` array is actually empty in Platformics, I realized it's probably better to just not make any non-null assumptions about Platformics responses anymore.