### PR TITLE
feat: Convert deposition page query to V2

### DIFF
--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -1,5 +1,15 @@
 import { Depositions_Bool_Exp } from 'app/__generated__/graphql'
-import { Tomogram_Reconstruction_Method_Enum } from 'app/__generated_v2__/graphql'
+import {
+  Annotation_File_Shape_Type_Enum,
+  DatasetWhereClause,
+  Fiducial_Alignment_Status_Enum,
+  Tomogram_Reconstruction_Method_Enum,
+} from 'app/__generated_v2__/graphql'
+import {
+  DEFAULT_TILT_RANGE_MAX,
+  DEFAULT_TILT_RANGE_MIN,
+} from 'app/constants/tiltSeries'
+import { FilterState } from 'app/hooks/useFilter'
 
 export const depositionWithAnnotationFilter: Depositions_Bool_Exp = {
   annotations_aggregate: {
@@ -27,4 +37,250 @@ export function convertReconstructionMethodToV2(
     default:
       return Tomogram_Reconstruction_Method_Enum.Unknown
   }
+}
+
+export interface GetDatasetsFilterParams {
+  filterState: FilterState
+  depositionId?: number
+  searchText?: string
+}
+
+export function getDatasetsFilter({
+  filterState,
+  depositionId,
+  searchText,
+}: GetDatasetsFilterParams): DatasetWhereClause {
+  const where: DatasetWhereClause = {}
+
+  // Search by Dataset Name
+  if (searchText) {
+    where.title = {
+      _ilike: `%${searchText}%`,
+    }
+  }
+
+  // INCLUDED CONTENTS SECTION
+  // Ground Truth Annotation
+  if (filterState.includedContents.isGroundTruthEnabled) {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.groundTruthStatus = {
+      _eq: true,
+    }
+  }
+  // Available Files
+  // TODO(bchu): Implement when available in API.
+  // filterState.includedContents.availableFiles.forEach((file) =>
+  //   match(file)
+  //     .with('raw-frames', () =>
+  //       where.push({
+  //         runs: {
+  //           tiltseries: {
+  //             frames_count: {
+  //               _gt: 0,
+  //             },
+  //           },
+  //         },
+  //       }),
+  //     )
+  //     .with('tilt-series', () =>
+  //       where.push({
+  //         runs: {
+  //           tiltseries_aggregate: {
+  //             count: {
+  //               predicate: {
+  //                 _gt: 0,
+  //               },
+  //             },
+  //           },
+  //         },
+  //       }),
+  //     )
+  //     .with('tilt-series-alignment', () =>
+  //       where.push({
+  //         runs: {
+  //           tiltseries: {
+  //             https_alignment_file: {
+  //               _is_null: false,
+  //             },
+  //           },
+  //         },
+  //       }),
+  //     )
+  //     .with('tomogram', () =>
+  //       where.push({
+  //         runs: {
+  //           tomogram_voxel_spacings: {
+  //             tomograms_aggregate: {
+  //               count: {
+  //                 predicate: {
+  //                   _gt: 0,
+  //                 },
+  //               },
+  //             },
+  //           },
+  //         },
+  //       }),
+  //     )
+  //     .exhaustive(),
+  // )
+  // Number of Runs
+  // TODO: Implement when available in API.
+  // if (filterState.includedContents.numberOfRuns) {
+  //   const runCount = +filterState.includedContents.numberOfRuns.slice(1)
+  //   where.push({
+  //     runs_aggregate: {
+  //       count: {
+  //         predicate: { _gte: runCount },
+  //       },
+  //     },
+  //   })
+  // }
+
+  // NAME/ID SECTION
+  // Dataset IDs
+  const datasetId =
+    filterState.ids.dataset !== null
+      ? parseInt(filterState.ids.dataset)
+      : undefined
+  if (Number.isInteger(datasetId)) {
+    where.id = {
+      _eq: datasetId,
+    }
+  }
+  const empiarId = filterState.ids.empiar
+  const emdbId = filterState.ids.emdb
+  if (empiarId && emdbId) {
+    where.relatedDatabaseEntries = {
+      _regex: `(EMPIAR-${empiarId}.*EMD-${emdbId})|(EMD-${emdbId}.*EMPIAR-${empiarId})`, // Ignores order
+    }
+  } else if (empiarId) {
+    where.relatedDatabaseEntries = {
+      _regex: `EMPIAR-${empiarId}`,
+    }
+  } else if (emdbId) {
+    where.relatedDatabaseEntries = {
+      _regex: `EMD-${emdbId}`,
+    }
+  }
+  // Dataset Author
+  if (filterState.author.name) {
+    where.authors ??= {}
+    where.authors.name = {
+      _ilike: `%${filterState.author.name}%`,
+    }
+  }
+  if (filterState.author.orcid) {
+    where.authors ??= {}
+    where.authors.orcid = {
+      _ilike: `%${filterState.author.orcid}%`,
+    }
+  }
+  // Deposition ID
+  const filterDepositionId =
+    filterState.ids.deposition !== null
+      ? parseInt(filterState.ids.deposition)
+      : undefined
+  if (depositionId !== undefined || Number.isInteger(filterDepositionId)) {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.depositionId = {
+      _eq: depositionId ?? filterDepositionId,
+    }
+  }
+
+  // SAMPLE AND EXPERIMENT CONDITIONS SECTION
+  const { organismNames } = filterState.sampleAndExperimentConditions
+  if (organismNames.length > 0) {
+    where.organismName = {
+      _in: organismNames,
+    }
+  }
+
+  // ANNOTATION METADATA SECTION
+  const { objectNames, objectId, objectShapeTypes } = filterState.annotation
+  // Object Name
+  if (objectNames.length > 0) {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.objectName = {
+      _in: objectNames,
+    }
+  }
+  // Object ID
+  if (objectId) {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.objectId = {
+      _eq: objectId,
+    }
+  }
+  // Object Shape Type
+  if (objectShapeTypes.length > 0) {
+    where.runs ??= { annotations: {} }
+    where.runs.annotations ??= {}
+    where.runs.annotations.annotationShapes = {
+      shapeType: {
+        _in: objectShapeTypes as Annotation_File_Shape_Type_Enum[], // TODO(bchu): Remove typecast.
+      },
+    }
+  }
+
+  // HARDWARE SECTION
+  if (filterState.hardware.cameraManufacturer) {
+    where.runs ??= { tiltseries: {} }
+    where.runs.tiltseries ??= {}
+    where.runs.tiltseries.cameraManufacturer = {
+      _eq: filterState.hardware.cameraManufacturer,
+    }
+  }
+
+  // TILT SERIES METADATA SECTION
+  const tiltRangeMin = parseFloat(filterState.tiltSeries.min)
+  const tiltRangeMax = parseFloat(filterState.tiltSeries.max)
+  if (Number.isFinite(tiltRangeMin) || Number.isFinite(tiltRangeMax)) {
+    where.runs ??= { tiltseries: {} }
+    where.runs.tiltseries ??= {}
+    where.runs.tiltseries.tiltRange = {
+      _gte: Number.isFinite(tiltRangeMin)
+        ? tiltRangeMin
+        : DEFAULT_TILT_RANGE_MIN,
+      _lte: Number.isFinite(tiltRangeMax)
+        ? tiltRangeMax
+        : DEFAULT_TILT_RANGE_MAX,
+    }
+  }
+
+  // TOMOGRAM METADATA SECTION
+  // Fiducial Alignment Status
+  if (filterState.tomogram.fiducialAlignmentStatus) {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.fiducialAlignmentStatus = {
+      _eq:
+        filterState.tomogram.fiducialAlignmentStatus === 'true'
+          ? Fiducial_Alignment_Status_Enum.Fiducial
+          : Fiducial_Alignment_Status_Enum.NonFiducial,
+    }
+  }
+  // Reconstruction Method
+  if (filterState.tomogram.reconstructionMethod) {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.reconstructionMethod = {
+      _eq: convertReconstructionMethodToV2(
+        filterState.tomogram.reconstructionMethod,
+      ),
+    }
+  }
+  // Reconstruction Software
+  if (filterState.tomogram.reconstructionSoftware) {
+    where.runs ??= { tomograms: {} }
+    where.runs.tomograms ??= {}
+    where.runs.tomograms.reconstructionSoftware = {
+      _eq: filterState.tomogram.reconstructionSoftware,
+    }
+  }
+
+  return where
 }

--- a/frontend/packages/data-portal/app/graphql/fragments/getDatasetsAggregatesV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDatasetsAggregatesV2.server.ts
@@ -4,12 +4,12 @@ import { gql } from 'app/__generated_v2__'
  * Shares aggregate queries between datasets and deposition pages (the 2 pages are very similar).
  *
  * Parent query must define the following variables:
- * - $datasetsFilter
- * - $datasetsByDepositionFilter
- * - $tiltseriesByDepositionFilter
- * - $tomogramsByDepositionFilter
- * - $annotationsByDepositionFilter
- * - $annotationShapesByDepositionFilter
+ * - $datasetsFilter: DatasetWhereClause
+ * - $datasetsByDepositionFilter: DatasetWhereClause
+ * - $tiltseriesByDepositionFilter: TiltseriesWhereClause
+ * - $tomogramsByDepositionFilter: TomogramWhereClause
+ * - $annotationsByDepositionFilter: AnnotationWhereClause
+ * - $annotationShapesByDepositionFilter: AnnotationShapeWhereClause
  */
 export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
   fragment DatasetsAggregates on Query {

--- a/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
@@ -5,21 +5,11 @@ import type {
 } from '@apollo/client'
 
 import { gql } from 'app/__generated_v2__'
-import {
-  Annotation_File_Shape_Type_Enum,
-  DatasetWhereClause,
-  Fiducial_Alignment_Status_Enum,
-  GetDatasetsV2Query,
-  OrderBy,
-} from 'app/__generated_v2__/graphql'
+import { GetDatasetsV2Query, OrderBy } from 'app/__generated_v2__/graphql'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
-import {
-  DEFAULT_TILT_RANGE_MAX,
-  DEFAULT_TILT_RANGE_MIN,
-} from 'app/constants/tiltSeries'
-import { FilterState, getFilterState } from 'app/hooks/useFilter'
+import { getFilterState } from 'app/hooks/useFilter'
 
-import { convertReconstructionMethodToV2 } from './common'
+import { getDatasetsFilter } from './common'
 
 const GET_DATASETS_QUERY = gql(`
   query GetDatasetsV2(
@@ -78,243 +68,6 @@ const GET_DATASETS_QUERY = gql(`
   }
 `)
 
-function getFilter(
-  filterState: FilterState,
-  searchText?: string,
-): DatasetWhereClause {
-  const where: DatasetWhereClause = {}
-
-  // Search by Dataset Name
-  if (searchText) {
-    where.title = {
-      _ilike: `%${searchText}%`,
-    }
-  }
-
-  // INCLUDED CONTENTS SECTION
-  // Ground Truth Annotation
-  if (filterState.includedContents.isGroundTruthEnabled) {
-    where.runs ??= { annotations: {} }
-    where.runs.annotations ??= {}
-    where.runs.annotations.groundTruthStatus = {
-      _eq: true,
-    }
-  }
-  // Available Files
-  // TODO(bchu): Implement when available in API.
-  // filterState.includedContents.availableFiles.forEach((file) =>
-  //   match(file)
-  //     .with('raw-frames', () =>
-  //       where.push({
-  //         runs: {
-  //           tiltseries: {
-  //             frames_count: {
-  //               _gt: 0,
-  //             },
-  //           },
-  //         },
-  //       }),
-  //     )
-  //     .with('tilt-series', () =>
-  //       where.push({
-  //         runs: {
-  //           tiltseries_aggregate: {
-  //             count: {
-  //               predicate: {
-  //                 _gt: 0,
-  //               },
-  //             },
-  //           },
-  //         },
-  //       }),
-  //     )
-  //     .with('tilt-series-alignment', () =>
-  //       where.push({
-  //         runs: {
-  //           tiltseries: {
-  //             https_alignment_file: {
-  //               _is_null: false,
-  //             },
-  //           },
-  //         },
-  //       }),
-  //     )
-  //     .with('tomogram', () =>
-  //       where.push({
-  //         runs: {
-  //           tomogram_voxel_spacings: {
-  //             tomograms_aggregate: {
-  //               count: {
-  //                 predicate: {
-  //                   _gt: 0,
-  //                 },
-  //               },
-  //             },
-  //           },
-  //         },
-  //       }),
-  //     )
-  //     .exhaustive(),
-  // )
-  // Number of Runs
-  // TODO: Implement when available in API.
-  // if (filterState.includedContents.numberOfRuns) {
-  //   const runCount = +filterState.includedContents.numberOfRuns.slice(1)
-  //   where.push({
-  //     runs_aggregate: {
-  //       count: {
-  //         predicate: { _gte: runCount },
-  //       },
-  //     },
-  //   })
-  // }
-
-  // NAME/ID SECTION
-  // Dataset IDs
-  const datasetId =
-    filterState.ids.dataset !== null
-      ? parseInt(filterState.ids.dataset)
-      : undefined
-  if (Number.isInteger(datasetId)) {
-    where.id = {
-      _eq: datasetId,
-    }
-  }
-  const empiarId = filterState.ids.empiar
-  const emdbId = filterState.ids.emdb
-  if (empiarId && emdbId) {
-    where.relatedDatabaseEntries = {
-      _regex: `(EMPIAR-${empiarId}.*EMD-${emdbId})|(EMD-${emdbId}.*EMPIAR-${empiarId})`, // Ignores order
-    }
-  } else if (empiarId) {
-    where.relatedDatabaseEntries = {
-      _regex: `EMPIAR-${empiarId}`,
-    }
-  } else if (emdbId) {
-    where.relatedDatabaseEntries = {
-      _regex: `EMD-${emdbId}`,
-    }
-  }
-  // Dataset Author
-  if (filterState.author.name) {
-    where.authors ??= {}
-    where.authors.name = {
-      _ilike: `%${filterState.author.name}%`,
-    }
-  }
-  if (filterState.author.orcid) {
-    where.authors ??= {}
-    where.authors.orcid = {
-      _ilike: `%${filterState.author.orcid}%`,
-    }
-  }
-  // Deposition ID
-  const depositionId =
-    filterState.ids.deposition !== null
-      ? parseInt(filterState.ids.deposition)
-      : undefined
-  if (Number.isInteger(depositionId)) {
-    where.depositionId = {
-      _eq: depositionId,
-    }
-  }
-
-  // SAMPLE AND EXPERIMENT CONDITIONS SECTION
-  const { organismNames } = filterState.sampleAndExperimentConditions
-  if (organismNames.length > 0) {
-    where.organismName = {
-      _in: organismNames,
-    }
-  }
-
-  // ANNOTATION METADATA SECTION
-  const { objectNames, objectId, objectShapeTypes } = filterState.annotation
-  // Object Name
-  if (objectNames.length > 0) {
-    where.runs ??= { annotations: {} }
-    where.runs.annotations ??= {}
-    where.runs.annotations.objectName = {
-      _in: objectNames,
-    }
-  }
-  // Object ID
-  if (objectId) {
-    where.runs ??= { annotations: {} }
-    where.runs.annotations ??= {}
-    where.runs.annotations.objectId = {
-      _eq: objectId,
-    }
-  }
-  // Object Shape Type
-  if (objectShapeTypes.length > 0) {
-    where.runs ??= { annotations: {} }
-    where.runs.annotations ??= {}
-    where.runs.annotations.annotationShapes = {
-      shapeType: {
-        _in: objectShapeTypes as Annotation_File_Shape_Type_Enum[], // TODO(bchu): Remove typecast.
-      },
-    }
-  }
-
-  // HARDWARE SECTION
-  if (filterState.hardware.cameraManufacturer) {
-    where.runs ??= { tiltseries: {} }
-    where.runs.tiltseries ??= {}
-    where.runs.tiltseries.cameraManufacturer = {
-      _eq: filterState.hardware.cameraManufacturer,
-    }
-  }
-
-  // TILT SERIES METADATA SECTION
-  const tiltRangeMin = parseFloat(filterState.tiltSeries.min)
-  const tiltRangeMax = parseFloat(filterState.tiltSeries.max)
-  if (Number.isFinite(tiltRangeMin) || Number.isFinite(tiltRangeMax)) {
-    where.runs ??= { tiltseries: {} }
-    where.runs.tiltseries ??= {}
-    where.runs.tiltseries.tiltRange = {
-      _gte: Number.isFinite(tiltRangeMin)
-        ? tiltRangeMin
-        : DEFAULT_TILT_RANGE_MIN,
-      _lte: Number.isFinite(tiltRangeMax)
-        ? tiltRangeMax
-        : DEFAULT_TILT_RANGE_MAX,
-    }
-  }
-
-  // TOMOGRAM METADATA SECTION
-  // Fiducial Alignment Status
-  if (filterState.tomogram.fiducialAlignmentStatus) {
-    where.runs ??= { tomograms: {} }
-    where.runs.tomograms ??= {}
-    where.runs.tomograms.fiducialAlignmentStatus = {
-      _eq:
-        filterState.tomogram.fiducialAlignmentStatus === 'true'
-          ? Fiducial_Alignment_Status_Enum.Fiducial
-          : Fiducial_Alignment_Status_Enum.NonFiducial,
-    }
-  }
-  // Reconstruction Method
-  if (filterState.tomogram.reconstructionMethod) {
-    where.runs ??= { tomograms: {} }
-    where.runs.tomograms ??= {}
-    where.runs.tomograms.reconstructionMethod = {
-      _eq: convertReconstructionMethodToV2(
-        filterState.tomogram.reconstructionMethod,
-      ),
-    }
-  }
-  // Reconstruction Software
-  if (filterState.tomogram.reconstructionSoftware) {
-    where.runs ??= { tomograms: {} }
-    where.runs.tomograms ??= {}
-    where.runs.tomograms.reconstructionSoftware = {
-      _eq: filterState.tomogram.reconstructionSoftware,
-    }
-  }
-
-  return where
-}
-
 export async function getDatasetsV2({
   page,
   titleOrderDirection,
@@ -331,7 +84,10 @@ export async function getDatasetsV2({
   return client.query({
     query: GET_DATASETS_QUERY,
     variables: {
-      datasetsFilter: getFilter(getFilterState(params), searchText),
+      datasetsFilter: getDatasetsFilter({
+        filterState: getFilterState(params),
+        searchText,
+      }),
       limit: MAX_PER_PAGE,
       offset: (page - 1) * MAX_PER_PAGE,
       // Default order primarily by release date.

--- a/frontend/packages/data-portal/app/graphql/getDepositionById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionById.server.ts
@@ -106,7 +106,7 @@ const GET_DEPOSITION_BY_ID = gql(`
 
       runs {
         tomogram_voxel_spacings {
-          annotations(distinct_on: object_name) {
+          annotations(distinct_on: object_name, where: { deposition_id: { _eq: $id }}) {
             object_name
           }
 

--- a/frontend/packages/data-portal/app/graphql/getDepositionById.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionById.server.ts
@@ -1,8 +1,16 @@
-import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import type {
+  ApolloClient,
+  ApolloQueryResult,
+  NormalizedCacheObject,
+} from '@apollo/client'
 import { match } from 'ts-pattern'
 
 import { gql } from 'app/__generated__'
-import { Datasets_Bool_Exp, Order_By } from 'app/__generated__/graphql'
+import {
+  Datasets_Bool_Exp,
+  GetDepositionByIdQuery,
+  Order_By,
+} from 'app/__generated__/graphql'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
 import { FilterState, getFilterState } from 'app/hooks/useFilter'
 import { getTiltRangeFilter } from 'app/utils/filter'
@@ -419,7 +427,7 @@ export async function getDepositionById({
   id: number
   page?: number
   params?: URLSearchParams
-}) {
+}): Promise<ApolloQueryResult<GetDepositionByIdQuery>> {
   return client.query({
     query: GET_DEPOSITION_BY_ID,
     variables: {

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -68,7 +68,7 @@ const GET_DEPOSITION_BY_ID = gql(`
           count
           groupBy {
             annotationShapes {
-              shapeType   
+              shapeType
             }
           }
         }

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -1,0 +1,460 @@
+import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import { match } from 'ts-pattern'
+
+import { Datasets_Bool_Exp, Order_By } from 'app/__generated__/graphql'
+import { gql } from 'app/__generated_v2__'
+import { MAX_PER_PAGE } from 'app/constants/pagination'
+import { FilterState, getFilterState } from 'app/hooks/useFilter'
+import { getTiltRangeFilter } from 'app/utils/filter'
+
+const GET_DEPOSITION_BY_ID = gql(`
+  query GetDepositionByIdV2(
+    $id: Int!,
+    $datasetLimit: Int,
+    $datasetOffset: Int,
+    $datasetOrderBy: OrderByEnum,
+    $filter: DatasetWhereClause!,
+  ) {
+    depositions(where: { id: { _eq: $id }}) {
+      edges {
+        node {
+          depositionDate
+          depositionPublications
+          description
+          id
+          keyPhotoUrl
+          lastModifiedDate
+          relatedDatabaseEntries
+          releaseDate
+          s3Prefix
+          title
+          authors(orderBy: { authorListOrder: asc }) {
+            edges {
+              node {
+                correspondingAuthorStatus
+                email
+                name
+                orcid
+                primaryAuthorStatus
+              }
+            }
+          }
+          annotations {
+            edges {
+              node {
+                files(distinctOn: shapeType) {
+                  edges {
+                    node {
+                      shapeType
+                    }
+                  }
+                }
+              }
+            }
+          }
+          annotationMethods: annotations(distinctOn: annotationMethod) {
+            edges {
+              node {
+                annotationMethod
+                annotationSoftware
+                methodLinks
+                methodType
+              }
+            }
+          }
+
+          annotationsAggregate {
+            aggregate {
+              count
+            }
+          }
+
+          organismNames: datasets(distinctOn: organismName) {
+            edges {
+              node {
+                organismName
+              }
+            }
+          }
+
+          objectNames: annotations(distinctOn: objectName) {
+            edges {
+              node {
+                objectName
+              }
+            }
+          }
+        }
+      }
+    }
+
+    datasets(
+      limitOffset: {
+        limit: $datasetLimit,
+        offset: $datasetOffset
+      },
+      orderBy: { title: $datasetOrderBy },
+      where: {
+        _and: [
+          $filter,
+          { runs: { annotations: { depositionId: { _eq: $id }}}}
+        ]
+      },
+    ) {
+      id
+      title
+      organismName
+      keyPhotoThumbnailUrl
+
+      authors(orderBy: { authorListOrder: asc }) {
+        edges {
+          node {
+            name
+            primaryAuthorStatus
+            correspondingAuthorStatus
+          }
+        }
+      }
+
+      runsAggregate(where: { annotations: { depositionId: { _eq: $id }}}) {
+        aggregate {
+          count
+        }
+      }
+
+      runs {
+        annotations(distinctOn: objectName) {
+          edges {
+            node {
+              objectName
+            }
+          }
+        }
+
+        annotationsAggregate(where: { depositionId: { _eq: $id }}) {
+          aggregate {
+            count
+          }
+        }
+      }
+    }
+
+    datasetsAggregate(where: { runs: { annotations: { depositionId: { _eq: $id }}}}) {
+      aggregate {
+        count
+      }
+    }
+
+    filteredDatasetsAggregate: datasetsAggregate(
+      where: {
+        _and: [
+          $filter,
+          { runs: { annotations: { depositionId: { _eq: $id }}}}
+        ]
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`)
+
+function getFilter(filterState: FilterState) {
+  const filters: Datasets_Bool_Exp[] = []
+
+  // TODO: combine this with getBrowseDatasets filter generator
+
+  // Included contents filters
+
+  // Ground truth filter
+  if (filterState.includedContents.isGroundTruthEnabled) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          annotations: {
+            ground_truth_status: {
+              _eq: true,
+            },
+          },
+        },
+      },
+    })
+  }
+
+  // Available files filter
+  filterState.includedContents.availableFiles.forEach((file) =>
+    match(file)
+      .with('raw-frames', () =>
+        filters.push({
+          runs: {
+            tiltseries: {
+              frames_count: {
+                _gt: 0,
+              },
+            },
+          },
+        }),
+      )
+      .with('tilt-series', () =>
+        filters.push({
+          runs: {
+            tiltseries_aggregate: {
+              count: {
+                predicate: {
+                  _gt: 0,
+                },
+              },
+            },
+          },
+        }),
+      )
+      .with('tilt-series-alignment', () =>
+        filters.push({
+          runs: {
+            tiltseries: {
+              https_alignment_file: {
+                _is_null: false,
+              },
+            },
+          },
+        }),
+      )
+      .with('tomogram', () =>
+        filters.push({
+          runs: {
+            tomogram_voxel_spacings: {
+              tomograms_aggregate: {
+                count: {
+                  predicate: {
+                    _gt: 0,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+      .exhaustive(),
+  )
+
+  // Number of runs filter
+  if (filterState.includedContents.numberOfRuns) {
+    const runCount = +filterState.includedContents.numberOfRuns.slice(1)
+    filters.push({
+      runs_aggregate: {
+        count: {
+          predicate: { _gte: runCount },
+        },
+      },
+    })
+  }
+
+  // Id filters
+  const idFilters: Datasets_Bool_Exp[] = []
+
+  // Dataset ID filter
+  const datasetId = +(filterState.ids.dataset ?? Number.NaN)
+  if (!Number.isNaN(datasetId) && datasetId > 0) {
+    idFilters.push({
+      id: {
+        _eq: datasetId,
+      },
+    })
+  }
+
+  // Empiar filter
+  const empiarId = filterState.ids.empiar
+  if (empiarId) {
+    idFilters.push({
+      related_database_entries: {
+        _like: `%EMPIAR-${empiarId}%`,
+      },
+    })
+  }
+
+  // EMDB filter
+  const emdbId = filterState.ids.emdb
+  if (emdbId) {
+    idFilters.push({
+      related_database_entries: {
+        _like: `%EMD-${emdbId}%`,
+      },
+    })
+  }
+
+  if (idFilters.length > 0) {
+    filters.push({ _or: idFilters })
+  }
+
+  // Author filters
+
+  // Author name filter
+  if (filterState.author.name) {
+    filters.push({
+      authors: {
+        name: {
+          _ilike: `%${filterState.author.name}%`,
+        },
+      },
+    })
+  }
+
+  // Author Orcid filter
+  if (filterState.author.orcid) {
+    filters.push({
+      authors: {
+        orcid: {
+          _ilike: `%${filterState.author.orcid}%`,
+        },
+      },
+    })
+  }
+
+  // Sample and experiment condition filters
+  const { organismNames } = filterState.sampleAndExperimentConditions
+
+  // Organism name filter
+  if (organismNames.length > 0) {
+    filters.push({
+      organism_name: { _in: organismNames },
+    })
+  }
+
+  // Hardware filters
+
+  // Camera manufacturer filter
+  if (filterState.hardware.cameraManufacturer) {
+    filters.push({
+      runs: {
+        tiltseries: {
+          camera_manufacturer: {
+            _eq: filterState.hardware.cameraManufacturer,
+          },
+        },
+      },
+    })
+  }
+
+  // Tilt series metadata filters
+  const tiltRangeFilter = getTiltRangeFilter(
+    filterState.tiltSeries.min,
+    filterState.tiltSeries.max,
+  )
+
+  if (tiltRangeFilter) {
+    filters.push({
+      runs: tiltRangeFilter,
+    })
+  }
+
+  // Tomogram metadata filters
+  if (filterState.tomogram.fiducialAlignmentStatus) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          tomograms: {
+            fiducial_alignment_status: {
+              _eq:
+                filterState.tomogram.fiducialAlignmentStatus === 'true'
+                  ? 'FIDUCIAL'
+                  : 'NON_FIDUCIAL',
+            },
+          },
+        },
+      },
+    })
+  }
+
+  // Reconstruction method filter
+  if (filterState.tomogram.reconstructionMethod) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          tomograms: {
+            reconstruction_method: {
+              _eq: filterState.tomogram.reconstructionMethod,
+            },
+          },
+        },
+      },
+    })
+  }
+
+  // Reconstruction software filter
+  if (filterState.tomogram.reconstructionSoftware) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          tomograms: {
+            reconstruction_software: {
+              _eq: filterState.tomogram.reconstructionSoftware,
+            },
+          },
+        },
+      },
+    })
+  }
+
+  // Annotation filters
+  const { objectNames, objectShapeTypes } = filterState.annotation
+
+  // Object names filter
+  if (objectNames.length > 0) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          annotations: {
+            object_name: {
+              _in: objectNames,
+            },
+          },
+        },
+      },
+    })
+  }
+
+  // Object shape type filter
+  if (objectShapeTypes.length > 0) {
+    filters.push({
+      runs: {
+        tomogram_voxel_spacings: {
+          annotations: {
+            files: {
+              shape_type: {
+                _in: objectShapeTypes,
+              },
+            },
+          },
+        },
+      },
+    })
+  }
+
+  return { _and: filters } as Datasets_Bool_Exp
+}
+
+export async function getDepositionById({
+  client,
+  id,
+  orderBy,
+  page = 1,
+  params = new URLSearchParams(),
+}: {
+  client: ApolloClient<NormalizedCacheObject>
+  orderBy?: Order_By | null
+  id: number
+  page?: number
+  params?: URLSearchParams
+}) {
+  return client.query({
+    query: GET_DEPOSITION_BY_ID,
+    variables: {
+      id,
+      dataset_limit: MAX_PER_PAGE,
+      dataset_offset: (page - 1) * MAX_PER_PAGE,
+      dataset_order_by: orderBy,
+      filter: getFilter(getFilterState(params)),
+    },
+  })
+}

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -39,20 +39,23 @@ const GET_DEPOSITION_BY_ID = gql(`
               }
             }
           }
-          annotations {
-            edges {
-              node {
-                files(distinctOn: shapeType) {
-                  edges {
-                    node {
-                      shapeType
+          distinctShapeTypes: annotationsAggregate {
+            aggregate {
+                count
+                groupBy {
+                    annotationShapes {
+                        shapeType
                     }
-                  }
                 }
-              }
             }
           }
-          annotationMethods: annotations(distinctOn: annotationMethod) {
+          annotationMethodCounts: annotationsAggregate {
+            aggregate {
+                count
+                groupBy {
+                    annotationMethod
+                }
+            }
             edges {
               node {
                 annotationMethod
@@ -88,6 +91,7 @@ const GET_DEPOSITION_BY_ID = gql(`
       }
     }
 
+    # This section is very similar to the datasets page.
     datasets(
       limitOffset: {
         limit: $datasetLimit,

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -1,28 +1,27 @@
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
-import { match } from 'ts-pattern'
 
-import { Datasets_Bool_Exp, Order_By } from 'app/__generated__/graphql'
+import { Order_By } from 'app/__generated__/graphql'
 import { gql } from 'app/__generated_v2__'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
-import { FilterState, getFilterState } from 'app/hooks/useFilter'
-import { getTiltRangeFilter } from 'app/utils/filter'
+import { getFilterState } from 'app/hooks/useFilter'
+
+import { getDatasetsFilter } from './common'
 
 const GET_DEPOSITION_BY_ID = gql(`
   query GetDepositionByIdV2(
-    $depositionId: Int!,
+    $id: Int!,
     $datasetsLimit: Int,
     $datasetsOffset: Int,
     $datasetsOrderBy: OrderByEnum,
     $datasetsFilter: DatasetWhereClause!,
-    # For DatasetsAggregates only:
-    $datasetsByDepositionFilter: DatasetWhereClause,
-    $tiltseriesByDepositionFilter: TiltseriesWhereClause,
-    $tomogramsByDepositionFilter: TomogramWhereClause,
-    $annotationsByDepositionFilter: AnnotationWhereClause,
-    $annotationShapesByDepositionFilter: AnnotationShapeWhereClause
+    $datasetsByDepositionFilter: DatasetWhereClause!,
+    $tiltseriesByDepositionFilter: TiltseriesWhereClause!,
+    $tomogramsByDepositionFilter: TomogramWhereClause!,
+    $annotationsByDepositionFilter: AnnotationWhereClause!,
+    $annotationShapesByDepositionFilter: AnnotationShapeWhereClause!
   ) {
     # Deposition:
-    depositions(where: { id: { _eq: $depositionId }}) {
+    depositions(where: { id: { _eq: $id }}) {
       depositionDate
       depositionPublications
       description
@@ -95,7 +94,7 @@ const GET_DEPOSITION_BY_ID = gql(`
     # Datasets:
     # This section is very similar to the datasets page.
     datasets(
-      where: $filter
+      where: $datasetsFilter
       orderBy: $orderBy,
       limitOffset: {
         limit: $limit,
@@ -116,7 +115,7 @@ const GET_DEPOSITION_BY_ID = gql(`
           }
         }
       }
-      runsCount: runsAggregate(where: { annotations: { depositionId: { _eq: $depositionId }}}) {
+      runsCount: runsAggregate(where: { annotations: $annotationsByDepositionFilter }) {
         aggregate {
           count
         }
@@ -124,7 +123,7 @@ const GET_DEPOSITION_BY_ID = gql(`
       runs {
         edges {
           node {
-            annotationsAggregate(where: { depositionId: { _eq: $depositionId }}) {
+            annotationsAggregate(where: $annotationsByDepositionFilter) {
               aggregate {
                 count
                 groupBy {
@@ -140,280 +139,6 @@ const GET_DEPOSITION_BY_ID = gql(`
     ...DatasetsAggregates
   }
 `)
-
-function getFilter(filterState: FilterState) {
-  const filters: Datasets_Bool_Exp[] = []
-
-  // TODO: combine this with getBrowseDatasets filter generator
-
-  // Included contents filters
-
-  // Ground truth filter
-  if (filterState.includedContents.isGroundTruthEnabled) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          annotations: {
-            ground_truth_status: {
-              _eq: true,
-            },
-          },
-        },
-      },
-    })
-  }
-
-  // Available files filter
-  filterState.includedContents.availableFiles.forEach((file) =>
-    match(file)
-      .with('raw-frames', () =>
-        filters.push({
-          runs: {
-            tiltseries: {
-              frames_count: {
-                _gt: 0,
-              },
-            },
-          },
-        }),
-      )
-      .with('tilt-series', () =>
-        filters.push({
-          runs: {
-            tiltseries_aggregate: {
-              count: {
-                predicate: {
-                  _gt: 0,
-                },
-              },
-            },
-          },
-        }),
-      )
-      .with('tilt-series-alignment', () =>
-        filters.push({
-          runs: {
-            tiltseries: {
-              https_alignment_file: {
-                _is_null: false,
-              },
-            },
-          },
-        }),
-      )
-      .with('tomogram', () =>
-        filters.push({
-          runs: {
-            tomogram_voxel_spacings: {
-              tomograms_aggregate: {
-                count: {
-                  predicate: {
-                    _gt: 0,
-                  },
-                },
-              },
-            },
-          },
-        }),
-      )
-      .exhaustive(),
-  )
-
-  // Number of runs filter
-  if (filterState.includedContents.numberOfRuns) {
-    const runCount = +filterState.includedContents.numberOfRuns.slice(1)
-    filters.push({
-      runs_aggregate: {
-        count: {
-          predicate: { _gte: runCount },
-        },
-      },
-    })
-  }
-
-  // Id filters
-  const idFilters: Datasets_Bool_Exp[] = []
-
-  // Dataset ID filter
-  const datasetId = +(filterState.ids.dataset ?? Number.NaN)
-  if (!Number.isNaN(datasetId) && datasetId > 0) {
-    idFilters.push({
-      id: {
-        _eq: datasetId,
-      },
-    })
-  }
-
-  // Empiar filter
-  const empiarId = filterState.ids.empiar
-  if (empiarId) {
-    idFilters.push({
-      related_database_entries: {
-        _like: `%EMPIAR-${empiarId}%`,
-      },
-    })
-  }
-
-  // EMDB filter
-  const emdbId = filterState.ids.emdb
-  if (emdbId) {
-    idFilters.push({
-      related_database_entries: {
-        _like: `%EMD-${emdbId}%`,
-      },
-    })
-  }
-
-  if (idFilters.length > 0) {
-    filters.push({ _or: idFilters })
-  }
-
-  // Author filters
-
-  // Author name filter
-  if (filterState.author.name) {
-    filters.push({
-      authors: {
-        name: {
-          _ilike: `%${filterState.author.name}%`,
-        },
-      },
-    })
-  }
-
-  // Author Orcid filter
-  if (filterState.author.orcid) {
-    filters.push({
-      authors: {
-        orcid: {
-          _ilike: `%${filterState.author.orcid}%`,
-        },
-      },
-    })
-  }
-
-  // Sample and experiment condition filters
-  const { organismNames } = filterState.sampleAndExperimentConditions
-
-  // Organism name filter
-  if (organismNames.length > 0) {
-    filters.push({
-      organism_name: { _in: organismNames },
-    })
-  }
-
-  // Hardware filters
-
-  // Camera manufacturer filter
-  if (filterState.hardware.cameraManufacturer) {
-    filters.push({
-      runs: {
-        tiltseries: {
-          camera_manufacturer: {
-            _eq: filterState.hardware.cameraManufacturer,
-          },
-        },
-      },
-    })
-  }
-
-  // Tilt series metadata filters
-  const tiltRangeFilter = getTiltRangeFilter(
-    filterState.tiltSeries.min,
-    filterState.tiltSeries.max,
-  )
-
-  if (tiltRangeFilter) {
-    filters.push({
-      runs: tiltRangeFilter,
-    })
-  }
-
-  // Tomogram metadata filters
-  if (filterState.tomogram.fiducialAlignmentStatus) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          tomograms: {
-            fiducial_alignment_status: {
-              _eq:
-                filterState.tomogram.fiducialAlignmentStatus === 'true'
-                  ? 'FIDUCIAL'
-                  : 'NON_FIDUCIAL',
-            },
-          },
-        },
-      },
-    })
-  }
-
-  // Reconstruction method filter
-  if (filterState.tomogram.reconstructionMethod) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          tomograms: {
-            reconstruction_method: {
-              _eq: filterState.tomogram.reconstructionMethod,
-            },
-          },
-        },
-      },
-    })
-  }
-
-  // Reconstruction software filter
-  if (filterState.tomogram.reconstructionSoftware) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          tomograms: {
-            reconstruction_software: {
-              _eq: filterState.tomogram.reconstructionSoftware,
-            },
-          },
-        },
-      },
-    })
-  }
-
-  // Annotation filters
-  const { objectNames, objectShapeTypes } = filterState.annotation
-
-  // Object names filter
-  if (objectNames.length > 0) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          annotations: {
-            object_name: {
-              _in: objectNames,
-            },
-          },
-        },
-      },
-    })
-  }
-
-  // Object shape type filter
-  if (objectShapeTypes.length > 0) {
-    filters.push({
-      runs: {
-        tomogram_voxel_spacings: {
-          annotations: {
-            files: {
-              shape_type: {
-                _in: objectShapeTypes,
-              },
-            },
-          },
-        },
-      },
-    })
-  }
-
-  return { _and: filters } as Datasets_Bool_Exp
-}
 
 export async function getDepositionById({
   client,
@@ -437,16 +162,21 @@ export async function getDepositionById({
   return client.query({
     query: GET_DEPOSITION_BY_ID,
     variables: {
-      depositionId: id,
+      id,
       datasetsLimit: MAX_PER_PAGE,
       datasetsOffset: (page - 1) * MAX_PER_PAGE,
       datasetsOrderBy: orderBy,
-      datasetsFilter: getFilter(getFilterState(params)),
+      datasetsFilter: getDatasetsFilter({
+        filterState: getFilterState(params),
+        depositionId: id,
+      }),
       datasetsByDepositionFilter: depositionIdFilter,
       tiltseriesByDepositionFilter: depositionIdFilter,
       tomogramsByDepositionFilter: depositionIdFilter,
       annotationsByDepositionFilter: depositionIdFilter,
-      annotationShapesByDepositionFilter: depositionIdFilter,
+      annotationShapesByDepositionFilter: {
+        annotation: depositionIdFilter,
+      },
     },
   })
 }

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -1,7 +1,11 @@
-import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+import type {
+  ApolloClient,
+  ApolloQueryResult,
+  NormalizedCacheObject,
+} from '@apollo/client'
 
 import { gql } from 'app/__generated_v2__'
-import { OrderBy } from 'app/__generated_v2__/graphql'
+import { GetDepositionByIdV2Query, OrderBy } from 'app/__generated_v2__/graphql'
 import { MAX_PER_PAGE } from 'app/constants/pagination'
 import { getFilterState } from 'app/hooks/useFilter'
 
@@ -139,19 +143,19 @@ const GET_DEPOSITION_BY_ID = gql(`
   }
 `)
 
-export async function getDepositionById({
+export async function getDepositionByIdV2({
   client,
   id,
   orderBy,
-  page = 1,
-  params = new URLSearchParams(),
+  page,
+  params,
 }: {
   client: ApolloClient<NormalizedCacheObject>
   orderBy?: OrderBy
   id: number
-  page?: number
-  params?: URLSearchParams
-}) {
+  page: number
+  params: URLSearchParams
+}): Promise<ApolloQueryResult<GetDepositionByIdV2Query>> {
   const depositionIdFilter = {
     depositionId: {
       _eq: id,

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -8,7 +8,7 @@ export type Deposition = NonNullable<GetDepositionByIdQuery['deposition']>
 export type Dataset = GetDepositionByIdQuery['datasets'][number]
 
 export function useDepositionById() {
-  const { v1: data, annotationMethodCounts } = useTypedLoaderData<{
+  const { v1, annotationMethodCounts } = useTypedLoaderData<{
     v1: GetDepositionByIdQuery
     annotationMethodCounts: Map<string, number>
   }>()
@@ -17,40 +17,39 @@ export function useDepositionById() {
     () =>
       Array.from(
         new Set(
-          data.deposition?.object_names.flatMap(
+          v1.deposition?.object_names.flatMap(
             (annotation) => annotation.object_name,
           ),
         ),
       ),
-    [data.deposition?.object_names],
+    [v1.deposition?.object_names],
   )
 
   const objectShapeTypes = useMemo(
     () =>
       Array.from(
         new Set(
-          data.deposition?.annotations.flatMap((annotation) =>
+          v1.deposition?.annotations.flatMap((annotation) =>
             annotation.files.flatMap((file) => file.shape_type),
           ),
         ),
       ),
-    [data.deposition?.annotations],
+    [v1.deposition?.annotations],
   )
 
   const organismNames = useMemo(
     () =>
       Array.from(
-        new Set(data.datasets.flatMap((dataset) => dataset.organism_name)),
+        new Set(v1.datasets.flatMap((dataset) => dataset.organism_name)),
       ).filter(Boolean) as string[],
-    [data.datasets],
+    [v1.datasets],
   )
 
   return {
-    deposition: data.deposition as Deposition,
-    datasets: data.datasets,
-    datasetsCount: data.datasets_aggregate.aggregate?.count ?? 0,
-    filteredDatasetsCount:
-      data.filtered_datasets_aggregate.aggregate?.count ?? 0,
+    deposition: v1.deposition as Deposition,
+    datasets: v1.datasets,
+    datasetsCount: v1.datasets_aggregate.aggregate?.count ?? 0,
+    filteredDatasetsCount: v1.filtered_datasets_aggregate.aggregate?.count ?? 0,
     objectNames,
     objectShapeTypes,
     organismNames,

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -8,8 +8,8 @@ export type Deposition = NonNullable<GetDepositionByIdQuery['deposition']>
 export type Dataset = GetDepositionByIdQuery['datasets'][number]
 
 export function useDepositionById() {
-  const { depositionData: data, annotationMethodCounts } = useTypedLoaderData<{
-    depositionData: GetDepositionByIdQuery
+  const { v1: data, annotationMethodCounts } = useTypedLoaderData<{
+    v1: GetDepositionByIdQuery
     annotationMethodCounts: Map<string, number>
   }>()
 

--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -132,6 +132,7 @@ export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
       QueryParams.ObjectName,
       QueryParams.ObjectId,
       QueryParams.ObjectShapeType,
+      QueryParams.Sort,
     ],
   })
 }

--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -7,7 +7,8 @@ import { useEffect } from 'react'
 import { typedjson } from 'remix-typedjson'
 
 import { Order_By } from 'app/__generated__/graphql'
-import { apolloClient } from 'app/apollo.server'
+import { OrderBy } from 'app/__generated_v2__/graphql'
+import { apolloClient, apolloClientV2 } from 'app/apollo.server'
 import { DatasetFilter } from 'app/components/DatasetFilter'
 import { DepositionMetadataDrawer } from 'app/components/Deposition'
 import { DatasetsTable } from 'app/components/Deposition/DatasetsTable'
@@ -19,6 +20,7 @@ import { QueryParams } from 'app/constants/query'
 import { getAnnotationCountForAnnotationMethod } from 'app/graphql/getAnnotationCountForAnnotationMethod'
 import { getDatasetsFilterData } from 'app/graphql/getDatasetsFilterData.server'
 import { getDepositionById } from 'app/graphql/getDepositionById.server'
+import { getDepositionByIdV2 } from 'app/graphql/getDepositionByIdV2.server'
 import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useI18n } from 'app/hooks/useI18n'
 import {
@@ -55,12 +57,18 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   let orderBy: Order_By | null = null
+  let orderByV2: OrderBy | undefined
 
   if (sort) {
     orderBy = sort === 'asc' ? Order_By.Asc : Order_By.Desc
+    orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
   }
 
-  const [depositionResponse, datasetsFilterReponse] = await Promise.all([
+  const [
+    { data: responseV1 },
+    { data: datasetsFilterReponse },
+    { data: responseV2 },
+  ] = await Promise.all([
     getDepositionById({
       id,
       orderBy,
@@ -72,18 +80,23 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       client: apolloClient,
       depositionId: id,
     }),
+    getDepositionByIdV2({
+      client: apolloClientV2,
+      id,
+      orderBy: orderByV2,
+      page,
+      params: url.searchParams,
+    }),
   ])
 
-  if (depositionResponse.data.deposition === null) {
+  if (responseV1.deposition == null) {
     throw new Response(null, {
       status: 404,
       statusText: `Deposition with ID ${id} not found`,
     })
   }
 
-  const deposition = depositionResponse.data.deposition as NonNullable<
-    typeof depositionResponse.data.deposition
-  >
+  const { deposition } = responseV1
 
   const annotationMethodCounts = new Map(
     await Promise.all(
@@ -104,9 +117,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   )
 
   return typedjson({
-    depositionData: depositionResponse.data,
-    v1FilterValues: datasetsFilterReponse.data,
+    v1: responseV1,
+    v1FilterValues: datasetsFilterReponse,
     annotationMethodCounts,
+    v2: responseV2,
   })
 }
 


### PR DESCRIPTION
Sends the new query to the BE but doesn't use any of the data yet.

Also factors filter logic for deposition and datasets pages into common function.

Also fixes bugs:
 - V1 query distinct object names per dataset weren't filtered by the deposition.
 - Changes to sort query param weren't refreshing Remix loader.