### PR TITLE
chore: Refactor datasets filter values fragment

### DIFF
--- a/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
@@ -1,13 +1,15 @@
 import { gql } from 'app/__generated_v2__'
 
 /**
- * Shares filter options queries between datasets and deposition pages (filters are near identical).
+ * Shares aggregate queries between datasets and deposition pages (the 2 pages are very similar).
  *
- * Parent query must define $depositionFilter.
+ * Parent query must define $depositionIdFilter. If $depositionIdFilter is undefined, the queries
+ *  will count everything. It makes the fragment significantly more readable to allow sending an
+ *  empty argument object.
  */
-export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
+export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
   fragment DatasetsAggregates on Query {
-    distinctOrganismNames: datasetsAggregate(where: { depositionId: $depositionFilter }) {
+    distinctOrganismNames: datasetsAggregate(where: { depositionId: $depositionIdFilter }) {
       aggregate {
         count
         groupBy {
@@ -16,7 +18,7 @@ export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
       }
     }
 
-    distinctCameraManufacturers: tiltseriesAggregate(where: { depositionId: $depositionFilter }) {
+    distinctCameraManufacturers: tiltseriesAggregate(where: { depositionId: $depositionIdFilter }) {
       aggregate {
         count
         groupBy {
@@ -25,7 +27,7 @@ export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
       }
     }
 
-    distinctReconstructionMethods: tomogramsAggregate(where: { depositionId: $depositionFilter }) {
+    distinctReconstructionMethods: tomogramsAggregate(where: { depositionId: $depositionIdFilter }) {
       aggregate {
         count
         groupBy {
@@ -34,7 +36,7 @@ export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
       }
     }
 
-    distinctReconstructionSoftwares: tomogramsAggregate(where: { depositionId: $depositionFilter }) {
+    distinctReconstructionSoftwares: tomogramsAggregate(where: { depositionId: $depositionIdFilter }) {
       aggregate {
         count
         groupBy {
@@ -43,7 +45,7 @@ export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
       }
     }
 
-    distinctObjectNames: annotationsAggregate(where: { depositionId: $depositionFilter }) {
+    distinctObjectNames: annotationsAggregate(where: { depositionId: $depositionIdFilter }) {
       aggregate {
         count
         groupBy {
@@ -52,7 +54,7 @@ export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
       }
     }
 
-    distinctShapeTypes: annotationShapesAggregate(where: { annotation: { depositionId: $depositionFilter } }) {
+    distinctShapeTypes: annotationShapesAggregate(where: { annotation: { depositionId: $depositionIdFilter } }) {
       aggregate {
         count
         groupBy {

--- a/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
@@ -6,7 +6,7 @@ import { gql } from 'app/__generated_v2__'
  * Parent query must define $depositionFilter.
  */
 export const GET_DATASETS_FILTER_VALUES_FRAGMENT = gql(`
-  fragment DatasetsFilterValues on Query {
+  fragment DatasetsAggregates on Query {
     distinctOrganismNames: datasetsAggregate(where: { depositionId: $depositionFilter }) {
       aggregate {
         count

--- a/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDatasetsFilterValuesV2.server.ts
@@ -3,13 +3,28 @@ import { gql } from 'app/__generated_v2__'
 /**
  * Shares aggregate queries between datasets and deposition pages (the 2 pages are very similar).
  *
- * Parent query must define $depositionIdFilter. If $depositionIdFilter is undefined, the queries
- *  will count everything. It makes the fragment significantly more readable to allow sending an
- *  empty argument object.
+ * Parent query must define the following variables:
+ * - $datasetsFilter
+ * - $datasetsByDepositionFilter
+ * - $tiltseriesByDepositionFilter
+ * - $tomogramsByDepositionFilter
+ * - $annotationsByDepositionFilter
+ * - $annotationShapesByDepositionFilter
  */
 export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
   fragment DatasetsAggregates on Query {
-    distinctOrganismNames: datasetsAggregate(where: { depositionId: $depositionIdFilter }) {
+    filteredDatasetsCount: datasetsAggregate(where: $datasetsFilter) {
+      aggregate {
+        count
+      }
+    }
+    totalDatasetsCount: datasetsAggregate(where: $datasetsByDepositionFilter) {
+      aggregate {
+        count
+      }
+    }
+
+    distinctOrganismNames: datasetsAggregate(where: $datasetsByDepositionFilter) {
       aggregate {
         count
         groupBy {
@@ -17,8 +32,7 @@ export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
         }
       }
     }
-
-    distinctCameraManufacturers: tiltseriesAggregate(where: { depositionId: $depositionIdFilter }) {
+    distinctCameraManufacturers: tiltseriesAggregate(where: $tiltseriesByDepositionFilter) {
       aggregate {
         count
         groupBy {
@@ -26,8 +40,7 @@ export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
         }
       }
     }
-
-    distinctReconstructionMethods: tomogramsAggregate(where: { depositionId: $depositionIdFilter }) {
+    distinctReconstructionMethods: tomogramsAggregate(where: $tomogramsByDepositionFilter) {
       aggregate {
         count
         groupBy {
@@ -35,8 +48,7 @@ export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
         }
       }
     }
-
-    distinctReconstructionSoftwares: tomogramsAggregate(where: { depositionId: $depositionIdFilter }) {
+    distinctReconstructionSoftwares: tomogramsAggregate(where: $tomogramsByDepositionFilter) {
       aggregate {
         count
         groupBy {
@@ -44,8 +56,7 @@ export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
         }
       }
     }
-
-    distinctObjectNames: annotationsAggregate(where: { depositionId: $depositionIdFilter }) {
+    distinctObjectNames: annotationsAggregate(where: $annotationsByDepositionFilter) {
       aggregate {
         count
         groupBy {
@@ -53,8 +64,7 @@ export const GET_DATASETS_AGGREGATES_FRAGMENT = gql(`
         }
       }
     }
-
-    distinctShapeTypes: annotationShapesAggregate(where: { annotation: { depositionId: $depositionIdFilter } }) {
+    distinctShapeTypes: annotationShapesAggregate(where: $annotationShapesByDepositionFilter) {
       aggregate {
         count
         groupBy {

--- a/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
@@ -27,7 +27,7 @@ const GET_DATASETS_QUERY = gql(`
     $offset: Int,
     $orderBy: [DatasetOrderByClause!]!,
     $filter: DatasetWhereClause!,
-    $depositionFilter: IntComparators # Unused, but must be defined because DatasetsFilterValues references it.
+    $depositionIdFilter: IntComparators # Unused, but must be defined because DatasetsFilterValues references it.
   ) {
     datasets(
       where: $filter
@@ -80,7 +80,7 @@ const GET_DATASETS_QUERY = gql(`
       }
     }
 
-    ...DatasetsFilterValues
+    ...DatasetsAggregates @include(if: $filterByDeposition)
   }
 `)
 

--- a/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
@@ -26,11 +26,16 @@ const GET_DATASETS_QUERY = gql(`
     $limit: Int,
     $offset: Int,
     $orderBy: [DatasetOrderByClause!]!,
-    $filter: DatasetWhereClause!,
-    $depositionIdFilter: IntComparators # Unused, but must be defined because DatasetsFilterValues references it.
+    $datasetsFilter: DatasetWhereClause!,
+    # Unused, but must be defined because DatasetsAggregates references them:
+    $datasetsByDepositionFilter: DatasetWhereClause,
+    $tiltseriesByDepositionFilter: TiltseriesWhereClause,
+    $tomogramsByDepositionFilter: TomogramWhereClause,
+    $annotationsByDepositionFilter: AnnotationWhereClause,
+    $annotationShapesByDepositionFilter: AnnotationShapeWhereClause
   ) {
     datasets(
-      where: $filter
+      where: $datasetsFilter
       orderBy: $orderBy,
       limitOffset: {
         limit: $limit,
@@ -69,18 +74,7 @@ const GET_DATASETS_QUERY = gql(`
       }
     }
 
-    totalDatasetsCount: datasetsAggregate {
-      aggregate {
-        count
-      }
-    }
-    filteredDatasetsCount: datasetsAggregate(where: $filter) {
-      aggregate {
-        count
-      }
-    }
-
-    ...DatasetsAggregates @include(if: $filterByDeposition)
+    ...DatasetsAggregates
   }
 `)
 
@@ -337,7 +331,7 @@ export async function getDatasetsV2({
   return client.query({
     query: GET_DATASETS_QUERY,
     variables: {
-      filter: getFilter(getFilterState(params), searchText),
+      datasetsFilter: getFilter(getFilterState(params), searchText),
       limit: MAX_PER_PAGE,
       offset: (page - 1) * MAX_PER_PAGE,
       // Default order primarily by release date.


### PR DESCRIPTION
 - Adds more shared fields into the fragment.
 - Stops sending empty argument objects when there is no `deposition` ID, based on previous findings that sending empty objects is not a no-op.