### PR TITLE
fix: Fix deposition filter on run page

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
@@ -223,9 +223,8 @@ function getRunFilter(
   // Deposition filter:
   const depositionId = +(filterState.ids.deposition ?? Number.NaN)
   if (!Number.isNaN(depositionId) && depositionId > 0) {
-    where.dataset = {
-      depositionId: { _eq: depositionId },
-    }
+    where.annotations ??= {}
+    where.annotations.depositionId = { _eq: depositionId }
   }
 
   // Tilt series filters:


### PR DESCRIPTION
I switched it to using dataset deposition when it should've been annotation deposition.