### PR TITLE
fix: correct alignment id in download modal

### DIFF
--- a/frontend/packages/data-portal/app/components/Download/ConfigureDownloadContent.tsx
+++ b/frontend/packages/data-portal/app/components/Download/ConfigureDownloadContent.tsx
@@ -10,11 +10,20 @@ import { ConfigureTomogramDownloadContent } from './ConfigureTomogramDownloadCon
 export function ConfigureDownloadContent() {
   const { t } = useI18n()
 
-  const { annotationName, annotationId, objectShapeType } =
+  const { annotationName, annotationId, objectShapeType, referenceTomogramId } =
     useDownloadModalQueryParamState()
 
-  const { annotationToDownload, datasetTitle, runName, objectName } =
-    useDownloadModalContext()
+  const {
+    annotationToDownload,
+    datasetTitle,
+    runName,
+    objectName,
+    allTomograms,
+  } = useDownloadModalContext()
+
+  const alignmentId = allTomograms?.find(
+    (tomogram) => tomogram.id === Number(referenceTomogramId),
+  )?.alignment?.id
 
   return (
     <>
@@ -35,10 +44,10 @@ export function ConfigureDownloadContent() {
       {objectShapeType && (
         <ModalSubtitle label={t('objectShapeType')} value={objectShapeType} />
       )}
-      {annotationToDownload !== undefined && (
+      {annotationToDownload !== undefined && alignmentId && (
         <ModalSubtitle
           label={t('alignmentId')}
-          value={`${IdPrefix.Alignment}-${annotationToDownload.id}`}
+          value={`${IdPrefix.Alignment}-${alignmentId}`}
         />
       )}
 

--- a/frontend/packages/data-portal/app/components/Download/DownloadOptionsContent.tsx
+++ b/frontend/packages/data-portal/app/components/Download/DownloadOptionsContent.tsx
@@ -137,15 +137,9 @@ export function DownloadOptionsContent() {
         tomogramToDownload?.alignment && (
           <ModalSubtitle
             label={t('alignmentId')}
-            value={tomogramToDownload.alignment.id}
+            value={`${IdPrefix.Alignment}-${tomogramToDownload.alignment.id}`}
           />
         )}
-      {annotationToDownload && (
-        <ModalSubtitle
-          label={t('alignmentId')}
-          value={`${IdPrefix.Alignment}-${annotationToDownload.id}`}
-        />
-      )}
       {fileFormat && (
         <ModalSubtitle
           label={t('fileFormat')}

--- a/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/AnnotationTable.tsx
@@ -345,8 +345,9 @@ export function AnnotationTable() {
                     datasetId: run.dataset.id,
                     runId: run.id,
                     annotationId: annotation.id,
-                    referenceTomogramId: tomograms.find(
-                      (tomogram) => tomogram.isPortalStandard,
+                    referenceTomogramId: (
+                      tomograms.find((tomogram) => tomogram.isPortalStandard) ??
+                      tomograms.at(0)
                     )?.id,
                     objectShapeType: annotation.shape_type,
                     fileFormat: annotation.format,


### PR DESCRIPTION
closes #1373 

before:
<img width="560" alt="Screenshot 2025-01-16 at 5 13 04 PM" src="https://github.com/user-attachments/assets/6483f3dc-8483-4643-9ca9-9ce74c863f59" />

after:
<img width="556" alt="Screenshot 2025-01-16 at 5 13 30 PM" src="https://github.com/user-attachments/assets/cbdd4d23-56a7-4806-92c7-47b99cd782c9" />
