### PR TITLE
fix: Convert null to false for annotation authors in run page differ

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
@@ -297,10 +297,9 @@ export function logIfHasDiff(
         authors: {
           edges: file.annotation.authors.map((author) => ({
             node: {
-              primaryAuthorStatus: Boolean(author.primary_author_status),
-              correspondingAuthorStatus: Boolean(
-                author.corresponding_author_status,
-              ),
+              primaryAuthorStatus: author.primary_author_status ?? false,
+              correspondingAuthorStatus:
+                author.corresponding_author_status ?? false,
               name: author.name,
               email: author.email,
               orcid: author.orcid,

--- a/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
@@ -297,8 +297,10 @@ export function logIfHasDiff(
         authors: {
           edges: file.annotation.authors.map((author) => ({
             node: {
-              primaryAuthorStatus: author.primary_author_status ?? false,
-              correspondingAuthorStatus: author.corresponding_author_status,
+              primaryAuthorStatus: Boolean(author.primary_author_status),
+              correspondingAuthorStatus: Boolean(
+                author.corresponding_author_status,
+              ),
               name: author.name,
               email: author.email,
               orcid: author.orcid,


### PR DESCRIPTION
For some reason, `null`s in `annotationAuthors` were converted to `False` in V2, but not any of the other author objects...