### PR TITLE
fix: Fix intermittent issue where Remix does not replace initial DOM with hydrated version

### DIFF
--- a/frontend/packages/data-portal/app/components/BrowseData/DatasetTable.tsx
+++ b/frontend/packages/data-portal/app/components/BrowseData/DatasetTable.tsx
@@ -80,7 +80,7 @@ export function DatasetTable() {
     try {
       return [
         columnHelper.accessor('key_photo_thumbnail_url', {
-          header: () => <p />,
+          header: () => <td />,
 
           cell({ row: { original: dataset } }) {
             const datasetUrl = getDatasetUrl(dataset.id)
@@ -143,7 +143,7 @@ export function DatasetTable() {
                 width={DatasetTableWidths.id}
               >
                 <div className="flex flex-col flex-auto gap-sds-xxxs min-h-[100px]">
-                  <p
+                  <div
                     className={cnsNoMerge(
                       'text-sds-body-m leading-sds-body-m font-semibold text-sds-color-primitive-blue-400',
                       !isClickingOnEmpiarId &&
@@ -155,17 +155,17 @@ export function DatasetTable() {
                     ) : (
                       <TableLink to={datasetUrl}>{dataset.title}</TableLink>
                     )}
-                  </p>
+                  </div>
 
-                  <p className="text-sds-body-xxs leading-sds-body-xxs text-sds-color-semantic-text-base-primary">
+                  <div className="text-sds-body-xxs leading-sds-body-xxs text-sds-color-semantic-text-base-primary">
                     {isLoadingDebounced ? (
                       <Skeleton className="max-w-[120px]" variant="text" />
                     ) : (
                       `${t('datasetId')}: ${IdPrefix.Dataset}-${dataset.id}`
                     )}
-                  </p>
+                  </div>
 
-                  <p className="text-sds-body-xxs leading-sds-body-xxs text-sds-color-primitive-gray-500 mt-sds-s">
+                  <div className="text-sds-body-xxs leading-sds-body-xxs text-sds-color-primitive-gray-500 mt-sds-s">
                     {isLoadingDebounced ? (
                       <>
                         <Skeleton className="max-w-[80%] mt-2" variant="text" />
@@ -178,7 +178,7 @@ export function DatasetTable() {
                     ) : (
                       <AuthorList authors={dataset.authors} compact />
                     )}
-                  </p>
+                  </div>
                 </div>
               </TableCell>
             )

--- a/frontend/packages/data-portal/app/components/Table/CellHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Table/CellHeader.tsx
@@ -53,7 +53,7 @@ export function CellHeader({
         !tooltip ? 'hover:!text-sds-color-semantic-text-base-secondary' : ''
       }
     >
-      <p className="line-clamp-1">
+      <div className="line-clamp-1">
         <Tooltip
           className="inline"
           tooltip={tooltip}
@@ -63,7 +63,7 @@ export function CellHeader({
         >
           {children}
         </Tooltip>
-      </p>
+      </div>
 
       {subHeader && (
         <p className="text-sds-body-xxxs leading-sds-body-xxxs font-normal">

--- a/frontend/packages/data-portal/app/components/Table/TableCell.tsx
+++ b/frontend/packages/data-portal/app/components/Table/TableCell.tsx
@@ -58,7 +58,7 @@ export function TableCell({
         className={cns('align-top px-3 py-4', cellProps.className)}
         style={cellProps.style}
       >
-        <p className="text-sds-body-s leading-sds-body-s font-normal">
+        <div className="text-sds-body-s leading-sds-body-s font-normal">
           <Tooltip
             className="inline"
             tooltip={primaryText}
@@ -67,7 +67,7 @@ export function TableCell({
           >
             {primaryText}
           </Tooltip>
-        </p>
+        </div>
       </td>
     )
   }


### PR DESCRIPTION
https://czi-sci.slack.com/archives/C05S98P75NW/p1737656647158829

Not sure why the actual UI bug occurs (sounds like a race condition in Remix?) but fixing the hydration errors (lot of something cannot be descendent of `<p>`) should prevent the wrong SSR HTML from being generated in the first place.