### PR TITLE
chore: Upgrade upload-artifact

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -170,7 +170,7 @@ jobs:
           E2E_CONFIG: ${{ secrets.E2E_CONFIG }}
           CI: true
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: html-report-${{ matrix.browser }}-${{ matrix.shardCurrent }}-${{ matrix.shardTotal }}

--- a/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
@@ -15,7 +15,7 @@ export interface MethodLinkProps {
   className?: string
   linkProps?: Partial<VariantLinkProps>
 }
-
+// test
 const METHOD_TYPE_TO_I18N_KEY: { [key in MethodLinkType]: I18nKeys } = {
   source_code: 'sourceCode',
   model_weights: 'modelWeights',

--- a/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
@@ -15,7 +15,7 @@ export interface MethodLinkProps {
   className?: string
   linkProps?: Partial<VariantLinkProps>
 }
-// test
+
 const METHOD_TYPE_TO_I18N_KEY: { [key in MethodLinkType]: I18nKeys } = {
   source_code: 'sourceCode',
   model_weights: 'modelWeights',


### PR DESCRIPTION
Tests action started refusing to run.

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```