### PR TITLE
feat: Finish migrating deposition and datasets aggregates to use V2

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/AnnotationsSummaryMetadataTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/AnnotationsSummaryMetadataTable.tsx
@@ -1,8 +1,10 @@
+import { Annotation_File_Shape_Type_Enum } from 'app/__generated_v2__/graphql'
 import { AccordionMetadataTable } from 'app/components/AccordionMetadataTable'
 import { CollapsibleList } from 'app/components/CollapsibleList'
-import { shapeTypeToI18nKeyPlural } from 'app/constants/objectShapeTypes'
+import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useI18n } from 'app/hooks/useI18n'
+import { checkExhaustive } from 'app/types/utils'
 import { getTableData } from 'app/utils/table'
 
 export function AnnotationsSummaryMetadataTable({
@@ -12,8 +14,9 @@ export function AnnotationsSummaryMetadataTable({
 }) {
   const { t } = useI18n()
 
-  const { deposition, objectNames, objectShapeTypes, organismNames } =
-    useDepositionById()
+  const { deposition } = useDepositionById()
+  const { organismNames, objectNames, objectShapeTypes } =
+    useDatasetsFilterData()
 
   const annotationsSummaryMetadata = getTableData(
     {
@@ -54,11 +57,22 @@ export function AnnotationsSummaryMetadataTable({
       values: [],
       renderValue: () => (
         <ul className="flex flex-col list-none gap-sds-xs text-sds-body-s leading-sds-body-s">
-          {Object.entries(shapeTypeToI18nKeyPlural)
-            .filter(([k]) => objectShapeTypes.includes(k))
-            .map(([k, v]) => (
-              <li key={k}>{t(v)}</li>
-            ))}
+          {objectShapeTypes.map((shapeType) => {
+            switch (shapeType) {
+              case Annotation_File_Shape_Type_Enum.InstanceSegmentation:
+                return <li key={shapeType}>{t('instanceSegmentations')}</li>
+              case Annotation_File_Shape_Type_Enum.OrientedPoint:
+                return <li key={shapeType}>{t('orientedPoints')}</li>
+              case Annotation_File_Shape_Type_Enum.Point:
+                return <li key={shapeType}>{t('points')}</li>
+              case Annotation_File_Shape_Type_Enum.SegmentationMask:
+                return <li key={shapeType}>{t('segmentationMasks')}</li>
+              case Annotation_File_Shape_Type_Enum.Mesh:
+                return <li key={shapeType}>{t('meshes')}</li>
+              default:
+                return checkExhaustive(shapeType)
+            }
+          })}
         </ul>
       ),
     },

--- a/frontend/packages/data-portal/app/constants/objectShapeTypes.ts
+++ b/frontend/packages/data-portal/app/constants/objectShapeTypes.ts
@@ -9,10 +9,3 @@ export const shapeTypeToI18nKey = {
   Point: 'point',
   SegmentationMask: 'segmentationMask',
 } as const satisfies ShapeTypeToI18nKeyMap
-
-export const shapeTypeToI18nKeyPlural = {
-  InstanceSegmentation: 'instanceSegmentations',
-  OrientedPoint: 'orientedPoints',
-  Point: 'points',
-  SegmentationMask: 'segmentationMasks',
-} as const satisfies ShapeTypeToI18nKeyMap

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -153,7 +153,11 @@ export async function getDepositionByIdV2({
         filterState: getFilterState(params),
         depositionId: id,
       }),
-      datasetsByDepositionFilter: depositionIdFilter,
+      datasetsByDepositionFilter: {
+        runs: {
+          annotations: depositionIdFilter,
+        },
+      },
       tiltseriesByDepositionFilter: depositionIdFilter,
       tomogramsByDepositionFilter: depositionIdFilter,
       annotationsByDepositionFilter: depositionIdFilter,

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -51,32 +51,6 @@ const GET_DEPOSITION_BY_ID = gql(`
           count
         }
       }
-      distinctOrganismNames: datasetsAggregate {
-        aggregate {
-          count
-          groupBy {
-            organismName
-          }
-        }
-      }
-      distinctObjectNames: annotationsAggregate {
-        aggregate {
-          count
-          groupBy {
-            objectName
-          }
-        }
-      }
-      distinctShapeTypes: annotationsAggregate {
-        aggregate {
-          count
-          groupBy {
-            annotationShapes {
-              shapeType
-            }
-          }
-        }
-      }
       annotationMethodCounts: annotationsAggregate {
         aggregate {
           count

--- a/frontend/packages/data-portal/app/graphql/getDepositionDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionDiffer.ts
@@ -73,30 +73,6 @@ export function logIfHasDiff(
   }
   // Counts not used.
   // Create consistent sort order.
-  for (const group of v2.depositions[0].distinctOrganismNames!.aggregate!) {
-    delete group.count
-  }
-  v2.depositions[0].distinctOrganismNames!.aggregate!.sort((groupA, groupB) =>
-    String(groupA.groupBy!.organismName).localeCompare(
-      String(groupB.groupBy!.organismName),
-    ),
-  )
-  for (const group of v2.depositions[0].distinctObjectNames!.aggregate!) {
-    delete group.count
-  }
-  v2.depositions[0].distinctObjectNames!.aggregate!.sort((groupA, groupB) =>
-    String(groupA.groupBy!.objectName).localeCompare(
-      String(groupB.groupBy!.objectName),
-    ),
-  )
-  for (const group of v2.depositions[0].distinctShapeTypes!.aggregate!) {
-    delete group.count
-  }
-  v2.depositions[0].distinctShapeTypes!.aggregate!.sort((groupA, groupB) =>
-    String(groupA.groupBy!.annotationShapes!.shapeType).localeCompare(
-      String(groupB.groupBy!.annotationShapes!.shapeType),
-    ),
-  )
   v2.depositions[0].annotationMethodCounts!.aggregate!.sort((groupA, groupB) =>
     String(groupA.groupBy!.annotationMethod).localeCompare(
       String(groupB.groupBy!.annotationMethod),
@@ -203,51 +179,6 @@ export function logIfHasDiff(
                   },
                 ]
               : [],
-        },
-        distinctOrganismNames: {
-          aggregate: v1
-            .deposition!.organism_names.map((dataset) => ({
-              groupBy: {
-                organismName: dataset.organism_name,
-              },
-            }))
-            .sort((groupA, groupB) =>
-              String(groupA.groupBy.organismName).localeCompare(
-                String(groupB.groupBy.organismName),
-              ),
-            ),
-        },
-        distinctObjectNames: {
-          aggregate: v1
-            .deposition!.object_names.map((annotation) => ({
-              groupBy: {
-                objectName: annotation.object_name,
-              },
-            }))
-            .sort((groupA, groupB) =>
-              String(groupA.groupBy.objectName).localeCompare(
-                String(groupB.groupBy.objectName),
-              ),
-            ),
-        },
-        distinctShapeTypes: {
-          aggregate: [
-            ...new Set(
-              v1.deposition!.annotations.flatMap((annotation) =>
-                annotation.files.map((file) => file.shape_type),
-              ),
-            ),
-          ]
-            .sort((shapeTypeA, shapeTypeB) =>
-              String(shapeTypeA).localeCompare(String(shapeTypeB)),
-            )
-            .map((shapeType) => ({
-              groupBy: {
-                annotationShapes: {
-                  shapeType: shapeType as Annotation_File_Shape_Type_Enum,
-                },
-              },
-            })),
         },
         annotationMethodCounts: {
           aggregate: [...v1AnnotationMethodCounts.entries()]

--- a/frontend/packages/data-portal/app/hooks/useDatasets.ts
+++ b/frontend/packages/data-portal/app/hooks/useDatasets.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
 import { GetDatasetsDataQuery } from 'app/__generated__/graphql'
@@ -10,18 +9,7 @@ export function useDatasets() {
     v1: GetDatasetsDataQuery
   }>()
 
-  return useMemo(
-    () => ({
-      datasets: v1.datasets,
-      datasetCount: v1.datasets_aggregate.aggregate?.count ?? 0,
-
-      filteredDatasetCount:
-        v1.filtered_datasets_aggregate.aggregate?.count ?? 0,
-    }),
-    [
-      v1.datasets,
-      v1.datasets_aggregate.aggregate?.count,
-      v1.filtered_datasets_aggregate.aggregate?.count,
-    ],
-  )
+  return {
+    datasets: v1.datasets,
+  }
 }

--- a/frontend/packages/data-portal/app/hooks/useDatasetsFilterData.ts
+++ b/frontend/packages/data-portal/app/hooks/useDatasetsFilterData.ts
@@ -12,6 +12,8 @@ export function useDatasetsFilterData() {
   }>()
 
   return {
+    filteredDatasetsCount: v2.filteredDatasetsCount.aggregate?.[0]?.count ?? 0,
+    totalDatasetsCount: v2.totalDatasetsCount.aggregate?.[0]?.count ?? 0,
     organismNames:
       v2.distinctOrganismNames.aggregate
         ?.map((aggregate) => aggregate.groupBy?.organismName)

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
 import { GetDepositionByIdQuery } from 'app/__generated__/graphql'
@@ -24,46 +23,9 @@ export function useDepositionById() {
       .filter((entry): entry is [string, number] => isDefined(entry[0])) ?? [],
   )
 
-  const objectNames = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          v1.deposition?.object_names.flatMap(
-            (annotation) => annotation.object_name,
-          ),
-        ),
-      ),
-    [v1.deposition?.object_names],
-  )
-
-  const objectShapeTypes = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          v1.deposition?.annotations.flatMap((annotation) =>
-            annotation.files.flatMap((file) => file.shape_type),
-          ),
-        ),
-      ),
-    [v1.deposition?.annotations],
-  )
-
-  const organismNames = useMemo(
-    () =>
-      Array.from(
-        new Set(v1.datasets.flatMap((dataset) => dataset.organism_name)),
-      ).filter(Boolean) as string[],
-    [v1.datasets],
-  )
-
   return {
     deposition: v1.deposition as Deposition,
     datasets: v1.datasets,
-    datasetsCount: v1.datasets_aggregate.aggregate?.count ?? 0,
-    filteredDatasetsCount: v1.filtered_datasets_aggregate.aggregate?.count ?? 0,
-    objectNames,
-    objectShapeTypes,
-    organismNames,
     annotationMethodCounts,
   }
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -19,7 +19,7 @@ import { getBrowseDatasets } from 'app/graphql/getBrowseDatasets.server'
 import { logIfHasDiff } from 'app/graphql/getDatasetsDiffer'
 import { getDatasetsFilterData } from 'app/graphql/getDatasetsFilterData.server'
 import { getDatasetsV2 } from 'app/graphql/getDatasetsV2.server'
-import { useDatasets } from 'app/hooks/useDatasets'
+import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useI18n } from 'app/hooks/useI18n'
 import {
   useBrowseDatasetFilterHistory,
@@ -83,7 +83,7 @@ function BrowseDatasetTableHeader(props: TableHeaderProps) {
 }
 
 export default function BrowseDatasetsPage() {
-  const { datasetCount, filteredDatasetCount } = useDatasets()
+  const { filteredDatasetsCount, totalDatasetsCount } = useDatasetsFilterData()
   const { t } = useI18n()
 
   const { setPreviousBrowseDatasetParams } = useBrowseDatasetFilterHistory()
@@ -104,8 +104,8 @@ export default function BrowseDatasetsPage() {
           filterPanel: <DatasetFilter />,
           table: <DatasetTable />,
           noFilteredResults: <NoFilteredResults showSearchTip />,
-          filteredCount: filteredDatasetCount,
-          totalCount: datasetCount,
+          filteredCount: filteredDatasetsCount,
+          totalCount: totalDatasetsCount,
           countLabel: t('datasets'),
           Header: BrowseDatasetTableHeader,
         },

--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -22,6 +22,7 @@ import { getDatasetsFilterData } from 'app/graphql/getDatasetsFilterData.server'
 import { getDepositionById } from 'app/graphql/getDepositionById.server'
 import { getDepositionByIdV2 } from 'app/graphql/getDepositionByIdV2.server'
 import { logIfHasDiff } from 'app/graphql/getDepositionDiffer'
+import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useI18n } from 'app/hooks/useI18n'
 import {
@@ -166,8 +167,8 @@ export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
 }
 
 export default function DepositionByIdPage() {
-  const { deposition, datasetsCount, filteredDatasetsCount } =
-    useDepositionById()
+  const { deposition } = useDepositionById()
+  const { filteredDatasetsCount, totalDatasetsCount } = useDatasetsFilterData()
   const { t } = useI18n()
 
   const { setPreviousDepositionId, setPreviousSingleDepositionParams } =
@@ -190,7 +191,7 @@ export default function DepositionByIdPage() {
         {
           title: t('datasetsWithDepositionData'),
           table: <DatasetsTable />,
-          totalCount: datasetsCount,
+          totalCount: totalDatasetsCount,
           filteredCount: filteredDatasetsCount,
           filterPanel: <DatasetFilter depositionPageVariant />,
           countLabel: t('datasets'),

--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -228,6 +228,7 @@
   "limitOneValuePerField": "Limit one value per field",
   "manual": "Manual",
   "meetsAll": "Meets all",
+  "meshes": "Meshes",
   "metadata": "Metadata",
   "methodCount": "Method {{ value }}",
   "methodLinks": "Method Links",


### PR DESCRIPTION
#1228 #1230

 - Switches all relevant code to use new V2 `DatasetsAggregates` fragment.
 - Removes some fields from the main deposition query that were already covered by the fragment.
 - Fix bug where total dataset count was querying for datasets with the deposition ID rather than datasets with annotations with the deposition ID.
 - This temporarily puts the data in the deposition page in an inconsistent state when using annotation filters, because the table is still using V1 whose query is technically wrong (it allows datasets that have annotations belonging to the deposition and any other annotation matching the annotation filter, rather than datasets that have annotations that both belong to the dataset and the annotation filter).