### PR TITLE
fix: Ignore __typename in diff logs

### DIFF
--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -276,7 +276,7 @@ export function getDatasetsFilter({
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, no-param-reassign, @typescript-eslint/no-unsafe-argument */
 // TODO(bchu): Delete this after migration.
 export function removeTypenames(object: any): void {
-  delete object?.__typename__
+  delete object?.__typename
 
   for (const [value] of Object.entries(object)) {
     if (typeof value === 'object' && !Array.isArray(value) && value !== null) {

--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -281,9 +281,7 @@ export function removeTypenames(object: any): void {
   for (const [, value] of Object.entries(object)) {
     if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
       removeTypenames(value)
-      continue
-    }
-    if (Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
       value.forEach(removeTypenames)
     }
   }

--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -272,3 +272,15 @@ export function getDatasetsFilter({
 
   return where
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, no-param-reassign, @typescript-eslint/no-unsafe-argument */
+// TODO(bchu): Delete this after migration.
+export function removeTypenames(object: any): void {
+  delete object?.__typename__
+
+  for (const [value] of Object.entries(object)) {
+    if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+      removeTypenames(value)
+    }
+  }
+}

--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -281,6 +281,10 @@ export function removeTypenames(object: any): void {
   for (const [, value] of Object.entries(object)) {
     if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
       removeTypenames(value)
+      continue
+    }
+    if (Array.isArray(value)) {
+      value.forEach(removeTypenames)
     }
   }
 }

--- a/frontend/packages/data-portal/app/graphql/common.ts
+++ b/frontend/packages/data-portal/app/graphql/common.ts
@@ -278,7 +278,7 @@ export function getDatasetsFilter({
 export function removeTypenames(object: any): void {
   delete object?.__typename
 
-  for (const [value] of Object.entries(object)) {
+  for (const [, value] of Object.entries(object)) {
     if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
       removeTypenames(value)
     }

--- a/frontend/packages/data-portal/app/graphql/getDatasetByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetByIdDiffer.ts
@@ -8,6 +8,8 @@ import {
   Tiltseries_Microscope_Manufacturer_Enum,
 } from 'app/__generated_v2__/graphql'
 
+import { removeTypenames } from './common'
+
 /* eslint-disable no-console, no-param-reassign */
 export function logIfHasDiff(
   url: string,
@@ -17,6 +19,7 @@ export function logIfHasDiff(
   console.log('Checking for dataset query diffs')
 
   v2 = structuredClone(v2)
+  removeTypenames(v2)
 
   // Counts not used.
   for (const run of v2.runs) {

--- a/frontend/packages/data-portal/app/graphql/getDatasetsDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsDiffer.ts
@@ -9,7 +9,7 @@ import {
   GetDatasetsV2Query,
 } from 'app/__generated_v2__/graphql'
 
-import { convertReconstructionMethodToV2 } from './common'
+import { convertReconstructionMethodToV2, removeTypenames } from './common'
 
 /* eslint-disable no-console, no-param-reassign */
 export function logIfHasDiff(
@@ -21,6 +21,7 @@ export function logIfHasDiff(
   console.log('Checking for datasets query diffs')
 
   v2 = structuredClone(v2)
+  removeTypenames(v2)
 
   // Counts not used.
   // Create consistent sort order.

--- a/frontend/packages/data-portal/app/graphql/getDepositionDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionDiffer.ts
@@ -12,7 +12,7 @@ import {
 } from 'app/__generated_v2__/graphql'
 import { MethodLinkDataType } from 'app/components/Deposition/MethodLinks/type'
 
-import { convertReconstructionMethodToV2 } from './common'
+import { convertReconstructionMethodToV2, removeTypenames } from './common'
 
 /* eslint-disable no-console, no-param-reassign */
 export function logIfHasDiff(
@@ -25,6 +25,7 @@ export function logIfHasDiff(
   console.log('Checking for deposition query diffs')
 
   v2 = structuredClone(v2)
+  removeTypenames(v2)
 
   // Condense per dataset annotation aggregates into single run where the first aggregate has the
   // count of all groups and all other counts are 0. The V1 counts are grouped by

--- a/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdDiffer.ts
@@ -12,6 +12,8 @@ import {
   Tomogram_Reconstruction_Method_Enum,
 } from 'app/__generated_v2__/graphql'
 
+import { removeTypenames } from './common'
+
 /* eslint-disable no-console, no-param-reassign, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return */
 export function logIfHasDiff(
   url: string,
@@ -21,6 +23,8 @@ export function logIfHasDiff(
   console.log('Checking for run query diffs')
 
   v2 = structuredClone(v2)
+  removeTypenames(v2)
+
   // There are no alignments in V1.
   delete v2.alignmentsAggregate.aggregate
   for (const annotationShape of v2.annotationShapes) {


### PR DESCRIPTION
Due to reenabling `__typename` in a previous PR.