### PR TITLE
fix: Add hover state for Download radio buttons

### DIFF
--- a/frontend/packages/data-portal/app/components/Radio/Radio.tsx
+++ b/frontend/packages/data-portal/app/components/Radio/Radio.tsx
@@ -33,6 +33,7 @@ export function Radio({
       className: cns(
         'flex gap-sds-default p-sds-l transition-colors text-left',
         isActive && 'bg-sds-color-primitive-gray-100',
+        'hover:bg-sds-color-primitive-gray-100',
       ),
       ...(isActive
         ? {}


### PR DESCRIPTION
Closes #271 

This activates the hover state for the Download Tomogram/All annotations radio buttons in the Download modal.

Preview below:

![download_modal](https://github.com/user-attachments/assets/7cda106e-02c7-48e8-9d13-0fb39a9010d0)
