### PR TITLE
fix: Update staging image_pull_policy

### DIFF
--- a/frontend/.happy/terraform/envs/staging/main.tf
+++ b/frontend/.happy/terraform/envs/staging/main.tf
@@ -36,6 +36,7 @@ module "stack" {
       initial_delay_seconds     = 100
       liveness_timeout_seconds  = 30
       readiness_timeout_seconds = 30
+      image_pull_policy         = "Always"
     }
   }
   create_dashboard = false


### PR DESCRIPTION
Relates to [#1531](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1531)

Updates the image_pull_policy in staging "IfNotPresent"->"Always".