### PR TITLE
fix: Stable version redirect

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,9 +118,9 @@ html_theme_options = {
             "aliases": [],
         },
         {
-            "version": "stable",
+            "version": "v3.0",
             "title": "Stable (v3.0)",
-            "aliases": [],
+            "aliases": ["stable"],
         },
     ],
 }


### PR DESCRIPTION
I didn't realize the version number and aliases should be switched in conf.py. This is not urgent but should fix future builds.

Follow-up to #1558 