### PR TITLE
fix: Update font to intended Inter font

### DIFF
--- a/frontend/packages/data-portal/app/root.tsx
+++ b/frontend/packages/data-portal/app/root.tsx
@@ -106,7 +106,7 @@ const Document = withEmotionCache(
           <link rel="preconnect" href="https://fonts.gstatic.com" />
 
           <link
-            href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,400;1,600;1,700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,100..900&display=swap"
             rel="stylesheet"
           />
 


### PR DESCRIPTION
I noticed that though the CSS said that Inter was the intended font it was not loaded. It does change the look and feel of the site a bit so I wanted give folks a heads up. 

In this PR:
Add Inter font in header