### PR TITLE
feat: Stop querying V1

### DIFF
--- a/frontend/packages/data-portal/app/hooks/useDepositions.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositions.ts
@@ -1,48 +1,15 @@
 import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
-import { GetDepositionsDataQuery } from 'app/__generated__/graphql'
 import { GetDepositionsDataV2Query } from 'app/__generated_v2__/graphql'
-import {
-  remapV1BrowseAllDepositions,
-  remapV2BrowseAllDepositions,
-} from 'app/apiNormalization'
-import { BrowseAllDepositionsPageDataType } from 'app/types/PageData/browseAllDepositionsPageData'
-import { pickAPISource } from 'app/utils/apiMigration'
+import { remapV2BrowseAllDepositions } from 'app/apiNormalization'
 
 export function useDepositions() {
-  const { v1, v2 } = useTypedLoaderData<{
-    v1: GetDepositionsDataQuery
+  const { v2 } = useTypedLoaderData<{
     v2: GetDepositionsDataV2Query
   }>()
 
-  const v1result = useMemo(() => remapV1BrowseAllDepositions(v1), [v1])
   const v2result = useMemo(() => remapV2BrowseAllDepositions(v2), [v2])
 
-  const combined = useMemo(
-    () =>
-      pickAPISource<BrowseAllDepositionsPageDataType>(
-        { v1: v1result, v2: v2result },
-        {
-          allObjectNames: 'v2',
-          allObjectShapeTypes: 'v2',
-          filteredDepositionCount: 'v2',
-          totalDepositionCount: 'v2',
-          depositions: {
-            acrossDatasets: 'v2',
-            annotationCount: 'v2',
-            annotatedObjects: 'v2',
-            authors: 'v2',
-            depositionDate: 'v2',
-            id: 'v2',
-            keyPhotoThumbnailUrl: 'v2',
-            objectShapeTypes: 'v2',
-            title: 'v2',
-          },
-        },
-      ),
-    [v1result, v2result],
-  )
-
-  return combined
+  return v2result
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.datasets.tsx
@@ -1,9 +1,8 @@
 import { CellHeaderDirection } from '@czi-sds/components'
 import { json, LoaderFunctionArgs } from '@remix-run/node'
 
-import { Order_By } from 'app/__generated__/graphql'
 import { OrderBy } from 'app/__generated_v2__/graphql'
-import { apolloClient, apolloClientV2 } from 'app/apollo.server'
+import { apolloClientV2 } from 'app/apollo.server'
 import { DatasetTable } from 'app/components/BrowseData'
 import { BrowseDataSearch } from 'app/components/BrowseData/BrowseDataSearch'
 import { DatasetFilter } from 'app/components/DatasetFilter'
@@ -15,9 +14,6 @@ import {
 } from 'app/components/TablePageLayout'
 import { DATASET_FILTERS } from 'app/constants/filterQueryParams'
 import { QueryParams } from 'app/constants/query'
-import { getBrowseDatasets } from 'app/graphql/getBrowseDatasets.server'
-import { logIfHasDiff } from 'app/graphql/getDatasetsDiffer'
-import { getDatasetsFilterData } from 'app/graphql/getDatasetsFilterData.server'
 import { getDatasetsV2 } from 'app/graphql/getDatasetsV2.server'
 import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useI18n } from 'app/hooks/useI18n'
@@ -34,46 +30,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | undefined
   const query = url.searchParams.get(QueryParams.Search) ?? ''
 
-  let orderBy: Order_By | null = null
   let orderByV2: OrderBy | undefined
 
   if (sort) {
-    orderBy = sort === 'asc' ? Order_By.Asc : Order_By.Desc
     orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
   }
 
-  const [
-    { data: responseV1 },
-    { data: filterValuesResponseV1 },
-    { data: responseV2 },
-  ] = await Promise.all([
-    getBrowseDatasets({
-      orderBy,
-      page,
-      query,
-      client: apolloClient,
-      params: url.searchParams,
-    }),
-    getDatasetsFilterData({ client: apolloClient }),
-    getDatasetsV2({
-      page,
-      titleOrderDirection: orderByV2,
-      searchText: query,
-      params: url.searchParams,
-      client: apolloClientV2,
-    }),
-  ])
-
-  try {
-    logIfHasDiff(request.url, responseV1, filterValuesResponseV1, responseV2)
-  } catch (error) {
-    // eslint-disable-next-line no-console, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    console.log(`DIFF ERROR: ${(error as any)?.stack}`)
-  }
+  const { data: responseV2 } = await getDatasetsV2({
+    page,
+    titleOrderDirection: orderByV2,
+    searchText: query,
+    params: url.searchParams,
+    client: apolloClientV2,
+  })
 
   return json({
-    v1: responseV1,
-    v1FilterValues: filterValuesResponseV1,
     v2: responseV2,
   })
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
@@ -1,16 +1,14 @@
 import { CellHeaderDirection } from '@czi-sds/components'
 import { json, LoaderFunctionArgs, redirect } from '@remix-run/node'
 
-import { Order_By } from 'app/__generated__/graphql'
 import { OrderBy } from 'app/__generated_v2__/graphql'
-import { apolloClient, apolloClientV2 } from 'app/apollo.server'
+import { apolloClientV2 } from 'app/apollo.server'
 import { DepositionTable } from 'app/components/BrowseData/DepositionTable'
 import {
   TableHeaderDefinition,
   TablePageLayout,
 } from 'app/components/TablePageLayout'
 import { QueryParams } from 'app/constants/query'
-import { getBrowseDepositions } from 'app/graphql/getBrowseDepositions.server'
 import { getBrowseDepositionsV2 } from 'app/graphql/getBrowseDepositionsV2.server'
 import { useDepositions } from 'app/hooks/useDepositions'
 import { useI18n } from 'app/hooks/useI18n'
@@ -33,33 +31,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const sort = (url.searchParams.get(QueryParams.Sort) ?? undefined) as
     | CellHeaderDirection
     | undefined
-  const query = url.searchParams.get(QueryParams.Search) ?? ''
 
-  let orderByV1: Order_By | null = null
   let orderByV2: OrderBy | null = null
 
   if (sort) {
-    orderByV1 = sort === 'asc' ? Order_By.Asc : Order_By.Desc
     orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
   }
 
-  const [{ data: responseV1 }, { data: responseV2 }] = await Promise.all([
-    getBrowseDepositions({
-      orderBy: orderByV1,
-      page,
-      query,
-      client: apolloClient,
-      params: url.searchParams,
-    }),
-    getBrowseDepositionsV2({
-      orderBy: orderByV2,
-      page,
-      client: apolloClientV2,
-    }),
-  ])
+  const { data: responseV2 } = await getBrowseDepositionsV2({
+    orderBy: orderByV2,
+    page,
+    client: apolloClientV2,
+  })
 
   return json({
-    v1: responseV1,
     v2: responseV2,
   })
 }

--- a/frontend/packages/data-portal/app/routes/datasets.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/datasets.$id.tsx
@@ -2,7 +2,7 @@
 
 import { json, LoaderFunctionArgs } from '@remix-run/server-runtime'
 
-import { apolloClient, apolloClientV2 } from 'app/apollo.server'
+import { apolloClientV2 } from 'app/apollo.server'
 import { DatasetMetadataDrawer } from 'app/components/Dataset'
 import { DatasetHeader } from 'app/components/Dataset/DatasetHeader'
 import { RunsTable } from 'app/components/Dataset/RunsTable'
@@ -13,8 +13,6 @@ import { RunFilter } from 'app/components/RunFilter'
 import { TablePageLayout } from 'app/components/TablePageLayout'
 import { RUN_FILTERS } from 'app/constants/filterQueryParams'
 import { QueryParams } from 'app/constants/query'
-import { getDatasetById } from 'app/graphql/getDatasetById.server'
-import { logIfHasDiff } from 'app/graphql/getDatasetByIdDiffer'
 import { getDatasetByIdV2 } from 'app/graphql/getDatasetByIdV2.server'
 import { useDatasetById } from 'app/hooks/useDatasetById'
 import { useI18n } from 'app/hooks/useI18n'
@@ -39,39 +37,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     })
   }
 
-  const [{ data: responseV1 }, { data: responseV2 }] = await Promise.all([
-    getDatasetById({
-      id,
-      page,
-      client: apolloClient,
-      params: url.searchParams,
-      depositionId: Number.isNaN(depositionId) ? undefined : depositionId,
-    }),
-    getDatasetByIdV2({
-      id,
-      page,
-      client: apolloClientV2,
-      params: url.searchParams,
-      depositionId: Number.isNaN(depositionId) ? undefined : depositionId,
-    }),
-  ])
+  const { data: responseV2 } = await getDatasetByIdV2({
+    id,
+    page,
+    client: apolloClientV2,
+    params: url.searchParams,
+    depositionId: Number.isNaN(depositionId) ? undefined : depositionId,
+  })
 
-  if (responseV1.datasets.length === 0) {
+  if (responseV2.datasets.length === 0) {
     throw new Response(null, {
       status: 404,
       statusText: `Dataset with ID ${id} not found`,
     })
   }
 
-  try {
-    logIfHasDiff(request.url, responseV1, responseV2)
-  } catch (error) {
-    // eslint-disable-next-line no-console, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    console.log(`DIFF ERROR: ${(error as any)?.stack}`)
-  }
-
   return json({
-    v1: responseV1,
     v2: responseV2,
   })
 }

--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -6,9 +6,8 @@ import { LoaderFunctionArgs, redirect } from '@remix-run/server-runtime'
 import { useEffect } from 'react'
 import { typedjson } from 'remix-typedjson'
 
-import { Order_By } from 'app/__generated__/graphql'
 import { OrderBy } from 'app/__generated_v2__/graphql'
-import { apolloClient, apolloClientV2 } from 'app/apollo.server'
+import { apolloClientV2 } from 'app/apollo.server'
 import { DatasetFilter } from 'app/components/DatasetFilter'
 import { DepositionMetadataDrawer } from 'app/components/Deposition'
 import { DatasetsTable } from 'app/components/Deposition/DatasetsTable'
@@ -17,11 +16,7 @@ import { NoFilteredResults } from 'app/components/NoFilteredResults'
 import { TablePageLayout } from 'app/components/TablePageLayout'
 import { DEPOSITION_FILTERS } from 'app/constants/filterQueryParams'
 import { QueryParams } from 'app/constants/query'
-import { getAnnotationCountForAnnotationMethod } from 'app/graphql/getAnnotationCountForAnnotationMethod'
-import { getDatasetsFilterData } from 'app/graphql/getDatasetsFilterData.server'
-import { getDepositionById } from 'app/graphql/getDepositionById.server'
 import { getDepositionByIdV2 } from 'app/graphql/getDepositionByIdV2.server'
-import { logIfHasDiff } from 'app/graphql/getDepositionDiffer'
 import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useI18n } from 'app/hooks/useI18n'
@@ -58,83 +53,21 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     })
   }
 
-  let orderBy: Order_By | null = null
   let orderByV2: OrderBy | undefined
 
   if (sort) {
-    orderBy = sort === 'asc' ? Order_By.Asc : Order_By.Desc
     orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
   }
 
-  const [
-    { data: responseV1 },
-    { data: datasetsFilterReponse },
-    { data: responseV2 },
-  ] = await Promise.all([
-    getDepositionById({
-      id,
-      orderBy,
-      page,
-      client: apolloClient,
-      params: url.searchParams,
-    }),
-    getDatasetsFilterData({
-      client: apolloClient,
-      depositionId: id,
-    }),
-    getDepositionByIdV2({
-      client: apolloClientV2,
-      id,
-      orderBy: orderByV2,
-      page,
-      params: url.searchParams,
-    }),
-  ])
-
-  if (responseV1.deposition == null) {
-    throw new Response(null, {
-      status: 404,
-      statusText: `Deposition with ID ${id} not found`,
-    })
-  }
-
-  const { deposition } = responseV1
-
-  const annotationMethodCounts = new Map(
-    await Promise.all(
-      deposition.annotation_methods.map((annotationMethod) =>
-        getAnnotationCountForAnnotationMethod({
-          client: apolloClient,
-          depositionId: deposition.id,
-          annotationMethod: annotationMethod.annotation_method,
-        }).then(
-          (result) =>
-            [
-              annotationMethod.annotation_method,
-              result.data.annotation_count.aggregate?.count ?? 0,
-            ] as const,
-        ),
-      ),
-    ),
-  )
-
-  try {
-    logIfHasDiff(
-      request.url,
-      responseV1,
-      datasetsFilterReponse,
-      annotationMethodCounts,
-      responseV2,
-    )
-  } catch (error) {
-    // eslint-disable-next-line no-console, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    console.log(`DIFF ERROR: ${(error as any)?.stack}`)
-  }
+  const { data: responseV2 } = await getDepositionByIdV2({
+    client: apolloClientV2,
+    id,
+    orderBy: orderByV2,
+    page,
+    params: url.searchParams,
+  })
 
   return typedjson({
-    v1: responseV1,
-    v1FilterValues: datasetsFilterReponse,
-    annotationMethodCounts,
     v2: responseV2,
   })
 }

--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -67,6 +67,13 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     params: url.searchParams,
   })
 
+  if (responseV2.depositions.length === 0) {
+    throw new Response(null, {
+      status: 404,
+      statusText: `Deposition with ID ${id} not found`,
+    })
+  }
+
   return typedjson({
     v2: responseV2,
   })


### PR DESCRIPTION
closes #1547

Not trying to change the shape of the object returning by the loader too much because there's a bug where if the loader return value changes in a non-backwards-compatible way, the app will be broken for a short period of time (?). Hopefully someone can figure that out and then update the loaders to remove the `v2` properties.

Not deleting the differs so we can still reference them while migrating the tests.