### PR TITLE
fix: All Annotations AWS CLI command

### DIFF
--- a/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
+++ b/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
@@ -26,7 +26,7 @@ export function getAwsCommand({
   const destinationPath = originPath?.split('/').pop()
 
   if (isAllAnnotations) {
-    const basePathMatch = s3Path?.match(/^(s3:\/\/[^/]+\/.*?\/Reconstructions)/)
+    const basePathMatch = s3Path?.match(/^([^/]+\/.*?\/Reconstructions)/)
     const basePath = basePathMatch ? basePathMatch[1] : ''
 
     return `${AWS_S3_BASE_COMMAND} ${s3Command} ${basePath}/ Annotations --exclude "*" --include "*/Annotations/*"`

--- a/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
+++ b/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
@@ -50,7 +50,7 @@ export function AWSDownloadTab() {
   })
     .with(
       { pathname: P.string.includes('/datasets') },
-      { isAllAnnotations },
+      { isAllAnnotations: true },
       { fileFormat: 'zarr' },
       () => 'sync' as const,
     )

--- a/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
+++ b/frontend/packages/data-portal/app/components/Download/AWSDownloadTab.tsx
@@ -41,21 +41,21 @@ export function AWSDownloadTab() {
   const { logPlausibleCopyEvent } = useLogPlausibleCopyEvent()
   const location = useLocation()
   const { downloadConfig, fileFormat } = useDownloadModalQueryParamState()
+  const isAllAnnotations = downloadConfig === DownloadConfig.AllAnnotations
 
   const s3Command = match({
     pathname: location.pathname,
-    downloadConfig,
+    isAllAnnotations,
     fileFormat,
   })
     .with(
       { pathname: P.string.includes('/datasets') },
-      { downloadConfig: DownloadConfig.AllAnnotations },
+      { isAllAnnotations },
       { fileFormat: 'zarr' },
       () => 'sync' as const,
     )
     .otherwise(() => 'cp' as const)
 
-  const isAllAnnotations = downloadConfig === DownloadConfig.AllAnnotations
   const awsCommand = getAwsCommand({ s3Path, s3Command, isAllAnnotations })
 
   return (

--- a/frontend/packages/data-portal/e2e/pageObjects/downloadDialog/downloadDialogActor.ts
+++ b/frontend/packages/data-portal/e2e/pageObjects/downloadDialog/downloadDialogActor.ts
@@ -348,6 +348,7 @@ export class DownloadDialogActor {
     const expectedCommand = getAwsCommand({
       s3Path: s3Prefix,
       s3Command: 'sync',
+      isAllAnnotations: true,
     })
     expect(clipboardValue).toBe(expectedCommand)
   }


### PR DESCRIPTION
Related to: https://github.com/chanzuckerberg/cryoet-data-portal/issues/1578

Update the All Annotations AWS CLI command snippet to iterate over all `VoxelSpacing` folders for annotations:
<img width="548" alt="Screenshot 2025-02-07 at 1 53 49 PM" src="https://github.com/user-attachments/assets/38a45e25-9777-4a54-ba9f-aeaaa4c71c2f" />
