### PR TITLE
fix: Disable firefox and webkit e2e tests during prod deploy

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       browsers:
         type: string
-        default: '["chromium", "firefox", "webkit"]'
+        default: '["chromium"]'
 
       environment:
         required: true

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -188,7 +188,7 @@ jobs:
     name: Notify slack channel
     runs-on: ubuntu-latest
     needs: [deploy-to-prod, find-frontend-release-pr]
-    if: needs.find-frontend-release-pr.outputs.pr != '' && !cancelled()
+    if: needs.deploy-to-prod.result == 'success' || needs.deploy-to-prod.result == 'failure'
 
     steps:
       - name: checkout repo for tagging


### PR DESCRIPTION
Also improve Slack message to only send if the prod deploy action actually ran.