### PR TITLE
fix: Auto accept Chromatic baseline changes to main

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -221,6 +221,7 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:
+          autoAcceptChanges: "main"
           playwright: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend/packages/data-portal

--- a/.github/workflows/frontend-pr-e2e-tests.yml
+++ b/.github/workflows/frontend-pr-e2e-tests.yml
@@ -1,7 +1,7 @@
 name: Frontend PR E2E Tests
 
 on:
-  pull_request:
+  push:
     branches:
       - '**'
     paths:


### PR DESCRIPTION
closes #1608 

I think this is necessary because of https://www.chromatic.com/docs/branching-and-baselines/#how-is-merge-base-calculated:~:text=The%20baseline%20is%20the%20last%20accepted%20snapshot%20on%20a%20given%20branch?

Seems like accepting new baselines on PRs only associates the new baselines with the PR's branch? So the action has to run again on `main` for the new baseline to be updated for future runs?