### PR TITLE
feat: Filter depositions by kaggleId or name in Author Name field

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
@@ -183,18 +183,14 @@ export async function getBrowseDepositionsV2({
       return resultsWithKaggleId
     }
 
-    const mergedDepositions = [
-      ...resultsWithName.data.depositions,
-      ...resultsWithKaggleId.data.depositions,
-    ].reduce(
-      (acc, curr) => {
-        if (!acc.some((dep) => dep.id === curr.id)) {
-          acc.push(curr)
-        }
-        return acc
-      },
-      [] as GetDepositionsDataV2Query['depositions'],
+    const depositionsMap = new Map(
+      [
+        ...resultsWithName.data.depositions,
+        ...resultsWithKaggleId.data.depositions,
+      ].map((dep) => [dep.id, dep]), // Map each deposition by its id
     )
+
+    const mergedDepositions = Array.from(depositionsMap.values())
 
     resultsWithName.data.depositions = mergedDepositions
 


### PR DESCRIPTION
After this change - users will also be able to put your kaggleId in the author name filter on depositions.
<img width="1224" alt="Screenshot 2025-02-27 at 4 30 09 PM" src="https://github.com/user-attachments/assets/8594bc5b-ce0c-42d4-bb1f-64cd651cbd2e" />

