### PR TITLE
fix: Make authors tooltip fit content properly

### DIFF
--- a/frontend/packages/data-portal/app/components/AuthorLegend.tsx
+++ b/frontend/packages/data-portal/app/components/AuthorLegend.tsx
@@ -42,7 +42,7 @@ function Legend() {
 
 export function AuthorLegend({ inline = false }: { inline?: boolean }) {
   return (
-    <Tooltip tooltip={<Legend />} placement="top">
+    <Tooltip tooltip={<Legend />} placement="top" sdsStyle="light" width="wide">
       <div
         className={inline ? 'relative w-sds-icon-s h-sds-icon-s' : undefined}
       >


### PR DESCRIPTION
It looks like the regular [SDS tooltip width is limited to 250px, but there is a wide option](https://sds.czi.design/009eaf17b/p/74af45-tooltips/t/page-74af45-76022550-3989d2-6) which is what I'm adding here.

Closes #1650 
