### PR TITLE
fix: fix depositions asc sort

### DIFF
--- a/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
+++ b/frontend/packages/data-portal/app/apiNormalization/browseAllDepositionsV2.ts
@@ -1,4 +1,7 @@
-import { GetDepositionsDataV2Query } from 'app/__generated_v2__/graphql'
+import {
+  GetDepositionsDataV2Query,
+  OrderBy,
+} from 'app/__generated_v2__/graphql'
 import {
   BrowseAllDepositionsPageDataType,
   Deposition,
@@ -37,36 +40,40 @@ const remapV2Deposition = remapAPI<
     deposition.annotationDatasetCount?.aggregate?.length ?? 0,
 } as const)
 
-export const remapV2BrowseAllDepositions = remapAPI<
-  GetDepositionsDataV2Query,
-  BrowseAllDepositionsPageDataType
->({
-  totalDepositionCount: (data) =>
-    data.totalDepositionCount?.aggregate?.at(0)?.count ?? 0,
-  filteredDepositionCount: (data) =>
-    data.filteredDepositionCount?.aggregate?.at(0)?.count ?? 0,
-  depositions: (data) =>
-    data.depositions.map(remapV2Deposition).sort((a, b) => {
-      const dateDiff =
-        new Date(b.depositionDate).getTime() -
-        new Date(a.depositionDate).getTime()
-      if (dateDiff !== 0) return dateDiff
-      return b.id - a.id
-    }),
-  allObjectNames: (data) =>
-    Array.from(
-      new Set(
-        data.allObjectNames?.aggregate
-          ?.map((aggregate) => aggregate.groupBy?.objectName ?? '')
-          .filter((value) => value !== '') ?? [],
-      ),
-    ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
-  allObjectShapeTypes: (data) =>
-    Array.from(
-      new Set(
-        data.allObjectShapeTypes?.aggregate?.map(
-          (aggregate) => aggregate.groupBy?.shapeType as ObjectShapeType,
-        ) ?? [],
-      ),
-    ).sort((a, b) => a.localeCompare(b)),
-} as const)
+export const remapV2BrowseAllDepositions = (
+  v2data: GetDepositionsDataV2Query,
+  sortDirection: OrderBy = OrderBy.Desc,
+) => {
+  return remapAPI<GetDepositionsDataV2Query, BrowseAllDepositionsPageDataType>({
+    totalDepositionCount: (data) =>
+      data.totalDepositionCount?.aggregate?.at(0)?.count ?? 0,
+    filteredDepositionCount: (data) =>
+      data.filteredDepositionCount?.aggregate?.at(0)?.count ?? 0,
+    depositions: (data) =>
+      data.depositions.map(remapV2Deposition).sort((a, b) => {
+        const dateDiff =
+          new Date(b.depositionDate).getTime() -
+          new Date(a.depositionDate).getTime()
+        if (dateDiff !== 0) {
+          return sortDirection === OrderBy.Desc ? dateDiff : -dateDiff
+        }
+        return sortDirection === OrderBy.Desc ? b.id - a.id : a.id - b.id
+      }),
+    allObjectNames: (data) =>
+      Array.from(
+        new Set(
+          data.allObjectNames?.aggregate
+            ?.map((aggregate) => aggregate.groupBy?.objectName ?? '')
+            .filter((value) => value !== '') ?? [],
+        ),
+      ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })),
+    allObjectShapeTypes: (data) =>
+      Array.from(
+        new Set(
+          data.allObjectShapeTypes?.aggregate?.map(
+            (aggregate) => aggregate.groupBy?.shapeType as ObjectShapeType,
+          ) ?? [],
+        ),
+      ).sort((a, b) => a.localeCompare(b)),
+  } as const)(v2data)
+}

--- a/frontend/packages/data-portal/app/hooks/useDepositions.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositions.ts
@@ -1,15 +1,21 @@
 import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
-import { GetDepositionsDataV2Query } from 'app/__generated_v2__/graphql'
+import {
+  GetDepositionsDataV2Query,
+  OrderBy,
+} from 'app/__generated_v2__/graphql'
 import { remapV2BrowseAllDepositions } from 'app/apiNormalization'
 
 export function useDepositions() {
-  const { v2 } = useTypedLoaderData<{
+  const { v2, orderBy } = useTypedLoaderData<{
     v2: GetDepositionsDataV2Query
+    orderBy: OrderBy
   }>()
-
-  const v2result = useMemo(() => remapV2BrowseAllDepositions(v2), [v2])
+  const v2result = useMemo(
+    () => remapV2BrowseAllDepositions(v2, orderBy),
+    [v2, orderBy],
+  )
 
   return v2result
 }

--- a/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
+++ b/frontend/packages/data-portal/app/routes/browse-data.depositions.tsx
@@ -34,11 +34,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     | CellHeaderDirection
     | undefined
 
-  let orderByV2: OrderBy | null = null
-
-  if (sort) {
-    orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
-  }
+  const orderByV2 = sort === 'asc' ? OrderBy.Asc : OrderBy.Desc
 
   const { data: responseV2 } = await getBrowseDepositionsV2({
     orderBy: orderByV2,
@@ -49,6 +45,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return json({
     v2: responseV2,
+    orderBy: orderByV2,
   })
 }
 


### PR DESCRIPTION
Addresses 🐞 : https://github.com/chanzuckerberg/cryoet-data-portal/issues/1660

Deposition table was not sorting correctly when "asc" was clicked. 

This PR ensures that the `remapV2BrowseAllDepositions` function is responsive to the direction of the sorting as well as the original gql response.
