### PR TITLE
fix: deposition annotations count

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/DatasetsTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DatasetsTable.tsx
@@ -240,14 +240,10 @@ export function DatasetsTable() {
 
         columnHelper.accessor(
           (dataset) =>
-            dataset.runs.edges
-              .flatMap(
-                (run) =>
-                  run.node.annotationsAggregate?.aggregate?.map(
-                    (aggregate) => aggregate.count ?? 0,
-                  ) ?? [],
-              )
-              .reduce((prevCount, nextCount) => prevCount + nextCount, 0),
+            deposition.annotationsAggregate?.aggregate?.find(
+              (agg) => agg.groupBy?.run?.dataset?.id === dataset.id,
+            )?.count ?? 0,
+
           {
             id: 'annotations',
 
@@ -328,6 +324,7 @@ export function DatasetsTable() {
     }
   }, [
     datasetSort,
+    deposition.annotationsAggregate?.aggregate,
     getDatasetUrl,
     isLoadingDebounced,
     searchParams,

--- a/frontend/packages/data-portal/app/components/Deposition/DepositionOverview.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DepositionOverview.tsx
@@ -71,7 +71,10 @@ export function DepositionOverview() {
               {t('annotations')}:
             </span>
             {(
-              deposition.annotationsAggregate?.aggregate?.[0]?.count ?? 0
+              deposition.annotationsAggregate?.aggregate?.reduce(
+                (total, { count }) => total + (count ?? 0),
+                0,
+              ) ?? 0
             ).toLocaleString()}
           </p>
         </div>

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -51,6 +51,14 @@ const GET_DEPOSITION_BY_ID = gql(`
       annotationsAggregate {
         aggregate {
           count
+
+          groupBy {
+            run {
+              dataset {
+                id
+              }
+            }
+          }
         }
       }
       annotationMethodCounts: annotationsAggregate {


### PR DESCRIPTION
#1641

Fixes annotation counts for the dataset table by getting the count from `annotationsAggregate` directly

## Before

<img width="1545" alt="image" src="https://github.com/user-attachments/assets/ee3ed4af-5713-438c-82f3-c5c2a2af1447" />

## After

<img width="1543" alt="image" src="https://github.com/user-attachments/assets/99dad132-a55a-4dcb-bd26-7806ffae8bbb" />
