### PR TITLE
chore: bump argus docker builder

### DIFF
--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   argus_builder:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.2.0
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v5
     secrets: inherit
     with:
       branches_include: ${{ inputs.branches_include }}


### PR DESCRIPTION
Use the latest major tag so it picks up all minor and patch releases