### PR TITLE
fix: Fix PR preview deployments to docs site

### DIFF
--- a/.github/workflows/docsite-build-deploy.yml
+++ b/.github/workflows/docsite-build-deploy.yml
@@ -57,9 +57,12 @@ jobs:
         run: |
           cd docs/
           make clean && make html
-          cp -r _build/html/* ../docsite/.
+          if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+          run: |
+            cp -r _build/html/* ../docsite/.
 
       - name: Deploy 🚀
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docsite # The folder the action should deploy.


### PR DESCRIPTION
I just realized that instead of just running the build docs job for pull requests, I was also deploying the site to the dev folder 😬 

This adds a guard to prevent the deployment if we are in a pull request.