### PR TITLE
fix: frames available

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -54,7 +54,7 @@ export function RunHeader() {
 
   const { openRunDownloadModal } = useDownloadModalQueryParamState()
 
-  const framesCount = run.framesAggregate?.aggregate?.[0]?.count ?? 0
+  const framesCount = run.frames.edges.length
   const tiltSeriesCount = run.tiltseriesAggregate?.aggregate?.[0]?.count ?? 0
   const annotationsCount = annotationFilesAggregates.totalCount
   const tomogramId = tomogramV2?.id?.toString()

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -186,11 +186,19 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
       }
 
       # Header
-      framesAggregate {
-        aggregate {
-          count
+      # Filter by non-null frame file path since it can be null
+      frames(where: {
+        httpsFramePath: {
+          _is_null: false
+        },
+      }) {
+        edges {
+          node {
+            id
+          }
         }
       }
+
       tiltseriesAggregate {
         aggregate {
           count


### PR DESCRIPTION
#1740

Updates query for getting frame data by fetching list of frames with non-null file paths instead of using the frame aggregate count.

