### PR TITLE
fix: tilt series quality score filter for multiple values

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetByIdV2.server.ts
@@ -287,7 +287,7 @@ function getRunFilter(
     where.tiltseries ??= {}
     where.tiltseries.tiltSeriesQuality = {
       _in: filterState.tiltSeries.qualityScore
-        .map((score) => parseInt(score))
+        .map((score) => parseInt(score, 10))
         .filter((val) => Number.isFinite(val)),
     }
   }


### PR DESCRIPTION
#1774

Fixes issue with the quality score filter when selecting multiple values. The issue is that passing `parseInt()` directly into the `map()` function behaves erroneously because it uses the 2nd argument of `map()` as the radix input for `parseInt()`:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a28fc0b9-70e1-4441-b570-7db0e70c264e" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7070b1f7-736c-4040-9b03-775e08d92ef0" />

## Before

<img width="195" alt="image" src="https://github.com/user-attachments/assets/6f686804-eb18-4aa1-9869-024a9668edcd" />

## After

<img width="195" alt="image" src="https://github.com/user-attachments/assets/3a95a960-7f32-42d6-80f7-a378ea4a6a7b" />
