### PR TITLE
fix: filter by non-null alignment method

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-10566ed
+        tag: sha-220418c
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -202,10 +202,12 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
     }
 
     # Header
-    alignmentsAggregate(where: {run: {id: {_eq: $id}}}) {
-      aggregate {
-        count
-      }
+    # Filter by non-null alignment method since it can be null
+    alignments(where: {
+      run: { id: { _eq: $id } },
+      alignmentMethod: { _is_null: false, },
+    }) {
+      id
     }
 
     # Annotations table

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -204,7 +204,6 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
     # Header
     # Filter by non-null alignment method since it can be null
     alignments(where: {
-      run: { id: { _eq: $id } },
       alignmentMethod: { _is_null: false, },
     }) {
       id

--- a/frontend/packages/data-portal/app/hooks/useRunById.ts
+++ b/frontend/packages/data-portal/app/hooks/useRunById.ts
@@ -77,7 +77,7 @@ export function useRunById() {
 
   const tomogramsCount = v2.tomogramsAggregate.aggregate?.[0].count ?? 0
   const ctfCount = v2.perSectionParametersAggregate.aggregate?.[0].count ?? 0
-  const alignmentsCount = v2.alignmentsAggregate.aggregate?.[0].count ?? 0
+  const alignmentsCount = v2.alignments.length
 
   const deposition = v2.depositions[0]
 


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:app=cryoet-frontend&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>App Name</th>
      <td>cryoet-frontend</td>
    </tr>
    <tr>
      <th>Stack Name</th>
      <td>pet-seagull</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://pet-seagull.dev-cryoet.dev.czi.team" target="_blank">https://pet-seagull.dev-cryoet.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:app=cryoet-frontend&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->

---

#1770

Updates query for getting alignment information by filtering by alignments with non-null methods