### PR TITLE
fix: view tomogram button propogration

### DIFF
--- a/frontend/packages/data-portal/app/components/ViewTomogramButton.tsx
+++ b/frontend/packages/data-portal/app/components/ViewTomogramButton.tsx
@@ -72,7 +72,10 @@ export function ViewTomogramButton({
        directly because Plausible will overwrite it. */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
-        onClick={trackViewTomogram}
+        onClick={(e) => {
+          e.stopPropagation()
+          trackViewTomogram()
+        }}
         onKeyDown={({ key }) => {
           if (key === 'Enter') {
             trackViewTomogram()
@@ -83,12 +86,7 @@ export function ViewTomogramButton({
         className="min-w-[152px]"
       >
         <Button
-          onClick={(e) => {
-            if (enabled) {
-              e.stopPropagation()
-              window.open(getNeuroglancerUrl(neuroglancerConfig), '_blank')
-            }
-          }}
+          href={enabled ? getNeuroglancerUrl(neuroglancerConfig) : undefined}
           disabled={!enabled}
           LinkComponent={Link}
           {...(buttonProps as ButtonProps)}


### PR DESCRIPTION
Follow up of #1782 to fix the `View tomogram` plausible event not firing on click. Instead of stopping propogation on the link itself, we can stop it in the outer div used for logging the plausible event. This will also allow us to restore the view tomogram button as a link which is semantically preferred.