### PR TITLE
fix: run alignments

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -213,6 +213,7 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
     # Filter by non-null alignment method since it can be null
     alignments(where: {
       alignmentMethod: { _is_null: false, },
+      runId: { _eq: $id }
     }) {
       id
     }


### PR DESCRIPTION
#1770

Re-adds where filter to alignments query that was accidentally removed in #1789. I didn't realize the `alignments` query was outside of `runs` 🤣 