### PR TITLE
fix: Fix version switcher behavior

### DIFF
--- a/docs/_static/js/version_redirect.js
+++ b/docs/_static/js/version_redirect.js
@@ -1,0 +1,11 @@
+window.addEventListener("DOMContentLoaded", function () {
+  versions = document.querySelectorAll(".md-version__item");
+  const currentUrl = window.location.href;
+  var currentVersion = currentUrl.match(/\/v\d+\.\d+(\-?rc\d+)?\/|\/dev\//g)[0];
+  var splitUrl = currentUrl.split(currentVersion);
+  versions.forEach((version) => {
+    var url = version.querySelector("a").getAttribute("href")
+    const redirectUrl = url + splitUrl[1];
+    version.querySelector("a").setAttribute("href", redirectUrl);
+  });
+});

--- a/docs/_templates/partials/header.html
+++ b/docs/_templates/partials/header.html
@@ -52,19 +52,14 @@
     <!-- Header title -->
     <div class="md-header__title">
       <div class="md-header__ellipsis">
-        <a
-        href="https://cryoetdataportal.czscience.com/"
-        title="CryoET Data Portal"
-        aria-label="CryoET Data Portal"
-        >
           <div class="md-header__topic">
             <div class="md-ellipsis--cet">
-              CryoET Data Portal <img src="_static/img/beta.svg" alt="CryoET Data Portal">
+              <a href="https://cryoetdataportal.czscience.com/" title="CryoET Data Portal" aria-label="CryoET Data Portal">CryoET Data Portal</a>
+              <img src="_static/img/beta.svg" alt="CryoET Data Portal">
             </div>
             <div class="hv"></div>
             <div class="md-ellipsis--cet">Documentation</div>
           </div>
-        </a>
       </div>
     </div>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ external_toc_exclude_missing = True
 # Inject custom css files in `/_static/css/*`
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
-html_js_files = ["js/faq.js"]
+html_js_files = ["js/faq.js", "js/version_redirect.js"]
 
 html_logo = ""
 html_title = "CryoET Data Portal Documentation"


### PR DESCRIPTION
Closes #1754

PREVIEW: https://melissawm.github.io/cryoet-data-portal/dev/data_model.html#data-model

To test:

- Verify that clicking on the version dropdown only opens the dropdown and doesn't navigate to the main portal page;
- Verify that for any pages/subpages, clicking on a different version in the dropdown correctly redirects to the same url, but with the selected version.
Example: navigating to
https://melissawm.github.io/cryoet-data-portal/dev/data_model.html#data-model
And clicking on the "Stable" version in the switcher should bring you to 
https://melissawm.github.io/cryoet-data-portal/v4.0/data_model.html#data-model