### PR TITLE
fix: depositions orcid filterby

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
@@ -139,10 +139,8 @@ export async function getBrowseDepositionsV2({
   const filters = getDepositionsFilter({
     filterState: getFilterState(params),
   })
-
   // If we have an author filter, we need to run two queries and merge the results
   if (filters.authors) {
-    console.log('filters', filters)
     // (smccanny - Feb 2025) We want to filter depositions by author name or kaggleId,
     // but the API only supports filtering by one at a time for now.
 
@@ -154,7 +152,7 @@ export async function getBrowseDepositionsV2({
         orcid: filters.authors.orcid,
       },
     }
-    delete filtersWithKaggleId.authors.name
+    delete filtersWithKaggleId?.authors?.name
 
     // Run both queries concurrently
     const [resultsWithName, resultsWithKaggleId]: [

--- a/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getBrowseDepositionsV2.server.ts
@@ -139,8 +139,10 @@ export async function getBrowseDepositionsV2({
   const filters = getDepositionsFilter({
     filterState: getFilterState(params),
   })
+
   // If we have an author filter, we need to run two queries and merge the results
   if (filters.authors) {
+    console.log('filters', filters)
     // (smccanny - Feb 2025) We want to filter depositions by author name or kaggleId,
     // but the API only supports filtering by one at a time for now.
 
@@ -149,9 +151,10 @@ export async function getBrowseDepositionsV2({
       authors: {
         name: filters.authors.name,
         kaggleId: filters.authors.name,
+        orcid: filters.authors.orcid,
       },
     }
-    delete filtersWithKaggleId?.authors?.name
+    delete filtersWithKaggleId.authors.name
 
     // Run both queries concurrently
     const [resultsWithName, resultsWithKaggleId]: [


### PR DESCRIPTION
Ticket: [#1742](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1742)

This fix means that you can now

- [x] find a deposition using an orcid 
- [x] find a deposition using an orcid & kaggleId (in the name field)
- [x] find a deposition using an orcid & name

<img width="1433" alt="Screenshot 2025-05-20 at 10 25 58 AM" src="https://github.com/user-attachments/assets/c3aaa281-acaa-445e-afb1-2c42afab4acc" />
