### PR TITLE
feat: dataset metadata drawer updates

### DIFF
--- a/frontend/packages/data-portal/app/components/Dataset/DatasetMetadataTable.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/DatasetMetadataTable.tsx
@@ -23,7 +23,7 @@ function DatasetDescription({ children }: { children: ReactNode }) {
       </span>
 
       <Button
-        startIcon={<Icon sdsIcon="Plus" sdsSize="xs" />}
+        startIcon={<Icon sdsIcon={showAll ? 'Minus' : 'Plus'} sdsSize="xs" />}
         sdsStyle="minimal"
         onClick={() => setShowAll((prev) => !prev)}
       >


### PR DESCRIPTION
#1809

- Enable dataset metadata drawer fields for dataset page
- Updated order of fields
- Add `Show More` button to description

## Demos

<img width="450" alt="image" src="https://github.com/user-attachments/assets/7c634b9e-5819-4840-a1d1-dbf0b2d74e61" />

<img width="450" alt="image" src="https://github.com/user-attachments/assets/f1249d3d-23a6-4eec-84b2-26f3e8b68809" />

<img width="450" alt="image" src="https://github.com/user-attachments/assets/778dc2e3-5a7d-441b-aced-55f83b729a43" />
