### PR TITLE
fix: deposition id prefix

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
+++ b/frontend/packages/data-portal/app/components/Run/TomogramMetadataDrawer.tsx
@@ -103,7 +103,7 @@ function MetadataTab() {
             label: t('depositionId'),
             values: [
               tomogram.deposition?.id !== undefined
-                ? `${IdPrefix.Dataset}-${tomogram.deposition.id}`
+                ? `${IdPrefix.Deposition}-${tomogram.deposition.id}`
                 : '',
             ],
           },


### PR DESCRIPTION
#1292

Fixes the prefix we use for the deposition ID

## Demo

### Before

<img width="430" alt="image" src="https://github.com/user-attachments/assets/d99e513c-9f94-492c-8dd5-65ecf1a79a34" />

### After

<img width="428" alt="image" src="https://github.com/user-attachments/assets/004ed242-725e-48ec-8450-0561909e3ba8" />
