### PR TITLE
feat: Add full changelog of Python Client to docs site

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,12 @@ help:
 
 .PHONY: help Makefile
 
+changelog:
+	cp ../client/python/cryoet_data_portal/CHANGELOG.md $(SOURCEDIR)/full_changelog.md
+
+html: changelog
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -9,7 +9,8 @@ subtrees:
     - entries:
       - file: api_reference.md
       - file: data_model.md
-      - file: changelog.md
+      - file: release_notes.md
+      - file: full_changelog.md
   - file: tutorials.md
     subtrees:
     - entries:

--- a/docs/full_changelog.md
+++ b/docs/full_changelog.md
@@ -1,0 +1,112 @@
+# Changelog
+
+## [4.4.1](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.4.0...cryoet-data-portal-python-client-v4.4.1) (2025-04-08)
+
+
+### 🧹 Miscellaneous Chores
+
+* Updating documentation ([830074d](https://github.com/chanzuckerberg/cryoet-data-portal/commit/830074d9f453a9a1afb77eae252082d108763ab3))
+* Updating documentation generation for PerSectionParameters ([#1751](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1751)) ([830074d](https://github.com/chanzuckerberg/cryoet-data-portal/commit/830074d9f453a9a1afb77eae252082d108763ab3))
+
+## [4.4.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.3.1...cryoet-data-portal-python-client-v4.4.0) (2025-03-24)
+
+
+### ✨ Features
+
+* Adding Frames and CTF components ([#1722](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1722)) ([8e82747](https://github.com/chanzuckerberg/cryoet-data-portal/commit/8e8274700f9ab12880c3de8e7ae29e7e73100c99))
+
+## [4.3.1](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.3.0...cryoet-data-portal-python-client-v4.3.1) (2025-02-18)
+
+
+### 🐞 Bug Fixes
+
+* Remove duplicated tooltip from Annotated Objects list ([#1460](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1460)) ([a42889e](https://github.com/chanzuckerberg/cryoet-data-portal/commit/a42889e933efb0cbb56a7d7825bf4199c40bdcd1))
+
+## [4.3.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.2.1...cryoet-data-portal-python-client-v4.3.0) (2024-12-19)
+
+
+### ✨ Features
+
+* add size fields to TiltSeries ([#1406](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1406)) ([3b8e709](https://github.com/chanzuckerberg/cryoet-data-portal/commit/3b8e709a5d44be4085be54c780723fb6910fb521))
+
+
+### 🧹 Miscellaneous Chores
+
+* update python matrix ([#1407](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1407)) ([639cd90](https://github.com/chanzuckerberg/cryoet-data-portal/commit/639cd901ca4c0def4baa1bdd6e8bd1aeb011a46e))
+
+## [4.2.1](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.2.0...cryoet-data-portal-python-client-v4.2.1) (2024-12-06)
+
+
+### 🐞 Bug Fixes
+
+* fix argument and return value handling for get_by_id ([#1380](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1380)) ([2504e4d](https://github.com/chanzuckerberg/cryoet-data-portal/commit/2504e4d8c5aaf5eae1afb69f24b62c77b2843d08))
+* Fix generated examples formatting ([#1369](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1369)) ([6cf8473](https://github.com/chanzuckerberg/cryoet-data-portal/commit/6cf847348365aa1f24f62123c4a50c9cb97ab25d))
+
+## [4.2.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.1.0...cryoet-data-portal-python-client-v4.2.0) (2024-11-27)
+
+
+### ✨ Features
+
+* Support a Client object being shared between threads. ([#1351](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1351)) ([ebdc7db](https://github.com/chanzuckerberg/cryoet-data-portal/commit/ebdc7db5069303b8d63481fdee990936c02b2a6a))
+
+
+### 🧹 Miscellaneous Chores
+
+* Make threading tests more concise. ([#1355](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1355)) ([538a480](https://github.com/chanzuckerberg/cryoet-data-portal/commit/538a480497bbb91f280aafa30664e4c9f5e055c4))
+
+## [4.1.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v4.0.0...cryoet-data-portal-python-client-v4.1.0) (2024-11-21)
+
+
+### ✨ Features
+
+* codegeneration for docstrings ([#1307](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1307)) ([cf0a008](https://github.com/chanzuckerberg/cryoet-data-portal/commit/cf0a0085bf39965bf06b7318af347f50eb0f9b32))
+
+
+### 🐞 Bug Fixes
+
+* Fixes for relationship field naming. ([#1348](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1348)) ([703d470](https://github.com/chanzuckerberg/cryoet-data-portal/commit/703d470787420c1f24f731004c6b62b5a13126a4))
+
+
+### 📝 Documentation
+
+* Final edits before ML Challenge ([#1313](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1313)) ([a675983](https://github.com/chanzuckerberg/cryoet-data-portal/commit/a67598344265d7dbec52ff5c1bfce79a3dd2dd2d))
+
+## [4.0.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v3.1.1...cryoet-data-portal-python-client-v4.0.0) (2024-10-30)
+
+
+### ⚠ BREAKING CHANGES
+
+* Initial support for apiv2 (https://github.com/chanzuckerberg/cryoet-data-portal/pull/1085)
+
+### ✨ Features
+
+* Initial support for apiv2 (https://github.com/chanzuckerberg/cryoet-data-portal/pull/1085) ([fec4000](https://github.com/chanzuckerberg/cryoet-data-portal/commit/fec400066d03361f68a9a12865842b83930f410c))
+
+## [3.1.1](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v3.1.0...cryoet-data-portal-python-client-v3.1.1) (2024-10-28)
+
+
+### 📝 Documentation
+
+* Move documentation site to Sphinx Immaterial ([#1087](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1087)) ([5d549dc](https://github.com/chanzuckerberg/cryoet-data-portal/commit/5d549dce37e69c1e9ddbf76c8cfaf28581419cda))
+
+## [3.1.0](https://github.com/chanzuckerberg/cryoet-data-portal/compare/cryoet-data-portal-python-client-v3.0.3...cryoet-data-portal-python-client-v3.1.0) (2024-08-22)
+
+
+### ✨ Features
+
+* add user agent to client requests ([#966](https://github.com/chanzuckerberg/cryoet-data-portal/issues/966)) ([8209cd4](https://github.com/chanzuckerberg/cryoet-data-portal/commit/8209cd46cb8ab21341c7ee94672db3bae78f9aa2))
+* Generate Python client code using GraphQL introspection ([#1008](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1008)) ([35b7265](https://github.com/chanzuckerberg/cryoet-data-portal/commit/35b72656e77132c9d64cc077705da8940bb29e44))
+
+
+### 🐞 Bug Fixes
+
+* create recursive_from_prefix path if it does not exist ([#940](https://github.com/chanzuckerberg/cryoet-data-portal/issues/940)) ([0069f08](https://github.com/chanzuckerberg/cryoet-data-portal/commit/0069f080987ac05efef82d024cb17f4dc307a0f3))
+* Use match with substring for exception check in client tests ([#895](https://github.com/chanzuckerberg/cryoet-data-portal/issues/895)) ([07352ec](https://github.com/chanzuckerberg/cryoet-data-portal/commit/07352ecdb8c6f50ffe97ff7be9777c0cf6dd66cb))
+* wait for graphql to be healthy in client tests ([#1044](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1044)) ([65f0a4b](https://github.com/chanzuckerberg/cryoet-data-portal/commit/65f0a4b76783ad32bbe439f62fc32f0cae3ae646)), closes [#942](https://github.com/chanzuckerberg/cryoet-data-portal/issues/942)
+
+
+### 🧹 Miscellaneous Chores
+
+* Add additional test case to TestGetDestinationPath ([#955](https://github.com/chanzuckerberg/cryoet-data-portal/issues/955)) ([a9412a8](https://github.com/chanzuckerberg/cryoet-data-portal/commit/a9412a80f3b24ff94b0803fdd59d3583b4521706))
+* add instructions and commands to manually release the python package. ([#1073](https://github.com/chanzuckerberg/cryoet-data-portal/issues/1073)) ([4833eb9](https://github.com/chanzuckerberg/cryoet-data-portal/commit/4833eb95d32ee06a5608e69d6aebf013b1c9fd73))
+* automate release of python client ([#972](https://github.com/chanzuckerberg/cryoet-data-portal/issues/972)) ([073bff7](https://github.com/chanzuckerberg/cryoet-data-portal/commit/073bff7180e2ac3b390cac6a5665b63a7f00e472))

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -21,10 +21,16 @@ Information on classes and methods
 Visualize the relationships between classes in the Python API
 :::
 
-:::{grid-item-card} Changelog
-:link: changelog
+:::{grid-item-card} Release Notes
+:link: release_notes
 :link-type: doc
 
 Log and migration guide for major API releases
 :::
+
+:::{grid-item-card} Changelog
+:link: full_changelog
+:link-type: doc
+
+Full changelog for the Python API Client
 ::::

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,7 @@
 hide-navigation: true
 ---
 
-# Changelog
+# Release Notes
 
 :::{czi-warning} Attention
 The v3 Python API was deprecated on Wednesday, February 26, 2025. Please update your Python API client to continue accessing the `cryoet-data-portal` package.


### PR DESCRIPTION
This PR adds the full changelog for the Python API client to the docs site. This is done by copying over the existing changelog file for the client into the docs sources and adding it as a new markdown page.

It also renames the current "Changelog" page to "Release notes" which is more appropriate since it contains highlights of major releases only. 