### PR TITLE
fix: Updating the workflow dispatch to deploy docsite

### DIFF
--- a/.github/workflows/docsite-build-deploy.yml
+++ b/.github/workflows/docsite-build-deploy.yml
@@ -57,12 +57,12 @@ jobs:
         run: |
           cd docs/
           make clean && make html
-          if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+          if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
           run: |
             cp -r _build/html/* ../docsite/.
 
       - name: Deploy 🚀
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docsite # The folder the action should deploy.


### PR DESCRIPTION
## Description

Currently, we require an update to the docs folder for the docsite to be deployed. This makes it cumbersome to update the doc-site for new client versions. 

The changes allow the doc-site to be deployed with manual trigger of the worklfow. 