### PR TITLE
feat: add XY-3d as option in layout

### DIFF
--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -392,6 +392,12 @@ export function ViewerPage({
                   {t('4panels')}
                 </NeuroglancerDropdownOption>
                 <NeuroglancerDropdownOption
+                  selected={isCurrentLayout('xy-3d')}
+                  onSelect={() => setCurrentLayout('xy-3d')}
+                >
+                  {t('xyAnd3D')}
+                </NeuroglancerDropdownOption>
+                <NeuroglancerDropdownOption
                   selected={isCurrentLayout('xy')}
                   onSelect={() => setCurrentLayout('xy')}
                 >

--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -676,6 +676,7 @@
   "whatIsCryoET": "What is CryoET?",
   "winningTeams": "10 Winning Teams",
   "withDepositionData": "With deposition data",
+  "xyAnd3D": "XY-3D",
   "yes": "Yes",
   "youMustHaveCliInstalled": "You must have AWS CLI installed. <url to='$t(awsCliLink)'>How to Install AWS CLI.</url>",
   "youMustHaveCurlInstalled": "You must have cURL installed. <url to='$t(curlSetupLink)'>How to Install cURL</url>",


### PR DESCRIPTION
Adds new layout option from a feature request, which shows XY and 3D side by side in the viewer

<img width="1860" height="879" alt="image" src="https://github.com/user-attachments/assets/396a69e8-4b5b-4e87-aa01-41e10aa0440f" />

cc @uermel and @codemonkey800 as I can't tag reviewers. Thanks!