### PR TITLE
fix: python client test workflow

### DIFF
--- a/.github/workflows/client-python.yml
+++ b/.github/workflows/client-python.yml
@@ -57,7 +57,7 @@ jobs:
   submit-codecoverage:
     needs:
       - test-client-python
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
GH Action Runners on MacOS don't actually have Docker, and the strategy matrix options aren't actually even using the `os` field (the "mac" tests are still using ubuntu-latest). 

Also fix the submit code coverage to not hang for 24hrs by changing the runner to `ubuntu-latest` instead of ubuntu 20.04.