### PR TITLE
fix: Move "separate-pull-requests" release-please option to root level of release-please config.

### DIFF
--- a/release-please.config.json
+++ b/release-please.config.json
@@ -1,4 +1,5 @@
 {
+  "separate-pull-requests": true,
   "changelog-sections": [
     { "type": "feat", "section": "✨ Features" },
     { "type": "fix", "section": "🐞 Bug Fixes" },
@@ -19,13 +20,11 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false,
-      "separate-pull-requests": true
+      "prerelease": false
     },
     "client/python/cryoet_data_portal": {
       "package-name": "cryoet-data-portal-python-client",
-      "release-type": "python",
-      "separate-pull-requests": true
+      "release-type": "python"
     }
   }
 }


### PR DESCRIPTION
The release-please config was setting the root-level option "separate-pull-requests" within the individual package contexts. This is causing the release-please action to report errors on every run. This PR moves the option to the root level, which should fix the recurring RP-action errors. 

see also: [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)