### PR TITLE
refactor: remove unused per-dataset distinctObjectNames from datasets…

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDatasetsV2.server.ts
@@ -63,17 +63,6 @@ const GET_DATASETS_QUERY = gql(`
           count
         }
       }
-      distinctObjectNames: runsAggregate {
-        aggregate {
-          count
-          groupBy {
-            annotations {
-              objectName
-              groundTruthStatus
-            }
-          }
-        }
-      }
       annotationsObjectNames: runsAggregate {
         aggregate {
           count


### PR DESCRIPTION
… query


### Summary
Remove unused `distinctObjectNames: runsAggregate` field from the per-dataset query in `getDatasetsV2.server.ts`. This was a duplicate of `annotationsObjectNames` (same query, different alias) and was never consumed by any component. The root-level distinctObjectNames in the DatasetsAggregates fragment (used by sidebar filters) is unaffected.

- Verified with `build:codegen` and `type-check` - both pass cleanly.

