### PR TITLE
fix: pass environment-specific API_URL_V2 during Docker build and CI codegen

### DIFF
--- a/.github/workflows/docker-build-rdev.yaml
+++ b/.github/workflows/docker-build-rdev.yaml
@@ -19,3 +19,4 @@ jobs:
       envs: rdev
       path_filters: 'frontend/**'
       branches_ignore: main,release-please--branches--main--components--cryoet-data-portal-frontend
+      api_url_v2: 'https://graphql.cryoet.staging.si.czi.technology/graphql'

--- a/.github/workflows/docker-build-staging-prod.yaml
+++ b/.github/workflows/docker-build-staging-prod.yaml
@@ -8,11 +8,22 @@ on:
     - release-please--branches--main--components--cryoet-data-portal-frontend
 
 jobs:
-  argus_builder:
+  build_staging:
     uses: ./.github/workflows/workflow-argus-docker-build.yaml
     secrets: inherit
     with:
-      envs: staging,prod
+      envs: staging
       path_filters: '!.infra/**,frontend/**'
       branches_include: release-please--branches--main--components--cryoet-data-portal-frontend
       force_update_manifests: true
+      api_url_v2: 'https://graphql.cryoet.staging.si.czi.technology/graphql'
+
+  build_prod:
+    uses: ./.github/workflows/workflow-argus-docker-build.yaml
+    secrets: inherit
+    with:
+      envs: prod
+      path_filters: '!.infra/**,frontend/**'
+      branches_include: release-please--branches--main--components--cryoet-data-portal-frontend
+      force_update_manifests: true
+      api_url_v2: 'https://graphql.cryoetdataportal.cziscience.com/graphql'

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -28,6 +28,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'prod' || 'staging' }}
 
     steps:
       - name: Checkout Repo
@@ -68,6 +69,8 @@ jobs:
       - name: Build GraphQL Types
         run: pnpm build:codegen
         working-directory: frontend/packages/data-portal
+        env:
+          API_URL_V2: ${{ vars.API_URL_V2 }}
 
       - name: ${{ matrix.name }}
         run: ${{ matrix.run }}

--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -7,6 +7,11 @@ on:
         description: "Env names, comma delimited"
         required: true
         type: string
+      api_url_v2:
+        description: "GraphQL API URL to use for codegen during Docker build"
+        required: false
+        type: string
+        default: ""
       path_filters:
         description: "Glob patterns to match against changed files in the repository, comma delimited"
         required: true
@@ -41,6 +46,7 @@ jobs:
         {
           "frontend": {
             "context": "frontend",
-            "dockerfile": "frontend/packages/data-portal/Dockerfile"
+            "dockerfile": "frontend/packages/data-portal/Dockerfile",
+            "build_args": "API_URL_V2=${{ inputs.api_url_v2 }}"
           }
         }

--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -47,6 +47,6 @@ jobs:
           "frontend": {
             "context": "frontend",
             "dockerfile": "frontend/packages/data-portal/Dockerfile",
-            "build_args": "API_URL_V2=${{ inputs.api_url_v2 }}"
+            "build_args": ["API_URL_V2=${{ inputs.api_url_v2 }}"]
           }
         }

--- a/frontend/packages/data-portal/Dockerfile
+++ b/frontend/packages/data-portal/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store npm -g i pnpm@8.10.5 && pnpm i --frozen-lockfile --ignore-scripts
 
 WORKDIR /app/packages/data-portal
-RUN pnpm build
+ARG API_URL_V2
+ENV API_URL_V2=$API_URL_V2
+RUN pnpm build 
 
 FROM node:20.10-alpine as server
 

--- a/frontend/packages/data-portal/Dockerfile
+++ b/frontend/packages/data-portal/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store npm -g i pnpm@8.10.5 && pnpm i
 WORKDIR /app/packages/data-portal
 ARG API_URL_V2
 ENV API_URL_V2=$API_URL_V2
-RUN pnpm build 
+RUN pnpm build
 
 FROM node:20.10-alpine as server
 


### PR DESCRIPTION
### Problem
During Docker image builds and CI test runs, the pnpm build:codegen step (which generates GraphQL types) was not being passed the correct GraphQL API endpoint. This caused codegen to either fail or generate types against the wrong environment's schema.

### Changes

- `dockerfile`:  Accept API_URL_V2 as a build arg and expose it as an env variable so pnpm build:codegen uses the correct endpoint during the Docker build step.
- `docker-build-rdev.yaml`: Passes the staging GraphQL URL  for rdev builds.
- `docker-build-staging-prod.yaml`:  Split the single argus_builder job into two separate jobs (build_staging, build_prod) so each env gets its own correct API URL.
