### PR TITLE
fix: trim leading whitespace in Object ID filter on apply

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-4a59a7e
+        tag: sha-ba16c0b
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/components/Filters/ObjectNameIdFilter/ObjectNameIdFilter.tsx
+++ b/frontend/packages/data-portal/app/components/Filters/ObjectNameIdFilter/ObjectNameIdFilter.tsx
@@ -209,7 +209,7 @@ export function ObjectNameIdFilter({
           (prev) => {
             filters.forEach((filter) => {
               prev.delete(filter.queryParam)
-              const value = values[filter.id]
+              const value = values[filter.id]?.trim()
 
               if (value) {
                 // Handle ObjectId with prefix removal


### PR DESCRIPTION
### Summary                                                                        
                  
  - Trims leading/trailing whitespace from filter input values before applying them in ObjectNameIdFilter #1991 
 