### PR TITLE
fix: disable i18next HTML escaping to prevent special chars being con…

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-c095cd6
+        tag: sha-3c4df5d
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/i18next.ts
+++ b/frontend/packages/data-portal/app/i18next.ts
@@ -1,6 +1,11 @@
 export const i18n = {
   supportedLngs: ['en'],
   fallbackLng: 'en',
+  // React already escapes JSX expressions, so disable i18next's HTML escaping
+  // to prevent special chars like "/" being converted to HTML entities (e.g. &#x2F;)
+  interpolation: {
+    escapeValue: false,
+  },
   react: {
     useSuspense: false,
     transWrapTextNodes: 'span',


### PR DESCRIPTION
…verted to HTML entities
                                                                                             
  Fixes #1957                                                                                      
  ### Summary
                                                                                                                             
  - Set `interpolation: { escapeValue: false }` in the shared i18next config                                                                                                          
                                                                                                                             
  ### Root cause                                                                                                              
 - i18next's default `escapeValue: true` HTML-encodes interpolated values, including `/` → `&#x2F;`. 
 - `escapeValue: false` disable i18next's HTML escaping to prevent special chars like "/" being converted to HTML entities (e.g. &#x2F;)              
                                                                                                              
                                                                  
                                                                            