### PR TITLE
fix: neuroglancer tomogram switcher fails on tomograms with many annotations

### DIFF
--- a/frontend/packages/neuroglancer/src/utils.ts
+++ b/frontend/packages/neuroglancer/src/utils.ts
@@ -248,8 +248,18 @@ export function compressHash(hash: string): string {
     return hash
   }
   const gzipHash = pako.gzip(hash2jsonString(hash))
-  // @ts-expect-error: UInt8Array and number[] are compatible in this context
-  const base64UrlFragment = btoa(String.fromCharCode.apply(null, gzipHash))
+  // String.fromCharCode.apply fills the stack when the array is large
+  // (e.g. many instance segmentation labels), so we need to do it in chunks
+  let binaryString = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < gzipHash.length; i += chunkSize) {
+    binaryString += String.fromCharCode.apply(
+      null,
+      // @ts-expect-error: Uint8Array and number[] are compatible here
+      gzipHash.subarray(i, i + chunkSize),
+    )
+  }
+  const base64UrlFragment = btoa(binaryString)
   const newHash = `#!${b64Tob64Url(base64UrlFragment)}`
   return newHash
 }


### PR DESCRIPTION
## Summary

Note: This PR has been largely written by Claude, but fully reviewed and tested by me.

Clicking a different tomogram in the Neuroglancer viewer fails on dataset 10490 with `Maximum call stack size exceeded` — the viewer never switches. Reproducible on staging if you view the neuroglancer tomogram viewer for https://frontend.cryoet.staging.si.czi.technology/datasets/10490.

## Root cause

`compressHash` in `packages/neuroglancer/src/utils.ts` converts the gzipped Neuroglancer state to base64 with:

```ts
btoa(String.fromCharCode.apply(null, gzipHash))
```

`Function.prototype.apply` spreads each byte into its own argument. JS engines cap argument counts (~65k Safari, ~125k V8), and exceeding that throws a `RangeError` that surfaces as "Maximum call stack size exceeded." 10490's state — ~27k segment IDs across 5 segmentation layers, each with an explicit `segmentColors` entry — gzips to well past the limit, so every state-write on that dataset fails. Smaller datasets stay under the threshold, which is why nothing else reproduces.

## Fix

Chunk the byte-to-string conversion into 32KB slices and concatenate. Bounded per-call argument count regardless of state size, no behavioral change for smaller states.

## Long-term follow-up (not in this PR)

This patch makes encoding correct at any size, but 10490's URL is still ~80KB compressed, which is fragile (browser/proxy/CDN URL limits, share-link UX). The bulk of that weight is per-segment metadata baked into the URL — primarily a `segmentColors` map with ~27k entries per layer, plus the `segments` allowlist (the visible/selected IDs).

Neuroglancer supports a [`segment_properties/info`](https://github.com/google/neuroglancer/blob/master/src/datasource/precomputed/segment_properties.md) precomputed format that hosts per-segment colors/names/properties as a server-fetched JSON file, so they don't need to live in the URL at all. Generating that during ingestion would address the `segmentColors` half of the bloat.

### How much would this actually save?

Moving colors out only gets you part of the way — every segment ID still has to live in the URL somewhere, either as a key in the color map today or in the `segments` (visible/selected) list after the change. The color map is the larger of the two (each entry carries both an id and a hex value, vs. just the id), so the savings are meaningful but partial — not a full fix. I'd want to measure 10490's actual state before putting a number on it. The right framing is that this buys headroom rather than removing the ceiling: a future dataset with even more segments could still push the URL back over a limit.

### The other half: the visible-segments list

The list of which segments are turned on doesn't go away with `segment_properties/info`, and Neuroglancer doesn't have a built-in way to serve that from the server. Once we've done the colors move and can see what's left, the options are basically: default to showing everything and let users deselect (so the list doesn't need to be in the URL at all), or find a more compact way to encode it (ranges, bitmaps). Either path is more involved — it would live in `ingestion_tools` / `apiv2`, and likely need an upstream Neuroglancer change.

### A note on layer-splitting

There's a separate effort to split one giant `InstanceSegmentationMask` into several layers — e.g. one per protein type, which is planned for 10490. Worth being clear that this doesn't solve the URL-size problem on its own: the total number of segments stays the same, just spread across more layers, and the URL size is the sum of all of them. It's a real UX win (users can toggle proteins, colors group sensibly) but it's a separate axis from the bloat. Moving colors to `segment_properties/info` and then dealing with the visible-segments list is what actually shrinks the URL.

