### PR TITLE
fix: nest frontend ingress paths under ingress key for stack chart schema

### DIFF
--- a/.infra/common.yaml
+++ b/.infra/common.yaml
@@ -20,6 +20,7 @@ stack:
     frontend:
       image:
         repository: 533267185808.dkr.ecr.us-west-2.amazonaws.com/core-platform/cryoet-data-portal/frontend/frontend
-      paths:
-      - /
-      pathType: Prefix
+      ingress:
+        paths:
+          - path: /
+            pathType: Prefix


### PR DESCRIPTION
Currently, any GH action runs that update / deploy to staging / prod with latest changes are blocked by the underlying bug this PR fixes.

The stack Helm chart (>=2.29.4) enforces a stricter values schema: each service is validated with `unevaluatedProperties: false`, and `paths`/`pathType` are only allowed nested under `services.<name>.ingress`, not directly on the service. The old format in common.yaml now fails schema validation during deploys (e.g. release-please staging stack creation: `at '/services/frontend/paths': false schema`). This nests them under `ingress` to match the schema; behavior is unchanged (path `/` + `Prefix` is the chart default). common.yaml is shared, so this fixes all envs.

Note: the breaking change was the 2.5.3 -> 2.29.4 bump (#1999), not the later 2.29.4 -> 2.31.0 bump (#2053) named in the failing run — those two schemas are identical.

References:
- stack chart source: https://github.com/chanzuckerberg/argo-helm-charts/tree/main/stack
- values schema (see `unevaluatedProperties: false` on services + `ingress.paths`): https://github.com/chanzuckerberg/argo-helm-charts/blob/main/stack/values.schema.json
- default values showing the `ingress.paths` format: https://github.com/chanzuckerberg/argo-helm-charts/blob/main/stack/values.yaml
- chart bump that introduced the strict schema: https://github.com/chanzuckerberg/cryoet-data-portal/pull/1999
- later no-op 2.31.0 bump: https://github.com/chanzuckerberg/cryoet-data-portal/pull/2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)