### PR TITLE
fix: collapse overflowing run metadata lists and consolidate annotatd object counts

### DIFF
--- a/frontend/packages/data-portal/app/components/DatabaseEntry.tsx
+++ b/frontend/packages/data-portal/app/components/DatabaseEntry.tsx
@@ -1,3 +1,4 @@
+import { CollapsibleList } from 'app/components/CollapsibleList'
 import { Link } from 'app/components/Link'
 import {
   DatabaseType,
@@ -59,16 +60,25 @@ export function DatabaseEntry(props: DatabaseEntryProps) {
   )
 }
 
-export function DatabaseEntryList({ entries }: { entries: string }) {
+export function DatabaseEntryList({
+  entries,
+  collapseAfter = 5,
+}: {
+  entries: string
+  collapseAfter?: number
+}) {
   return (
-    <ul className="flex flex-col gap-sds-xs text-sds-body-s-400-wide leading-sds-body-xs">
-      {entries.split(',').map((entry) => {
-        return (
-          <li key={entry}>
-            <DatabaseEntry entry={entry.trim()} inline />
-          </li>
-        )
-      })}
-    </ul>
+    <CollapsibleList
+      tableVariant
+      collapseAfter={collapseAfter}
+      entries={entries
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .map((entry) => ({
+          key: entry,
+          entry: <DatabaseEntry entry={entry} inline />,
+        }))}
+    />
   )
 }

--- a/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/SampleAndExperimentConditionsTable.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/SampleAndExperimentConditionsTable.tsx
@@ -1,4 +1,5 @@
 import { AccordionMetadataTable } from 'app/components/AccordionMetadataTable'
+import { CollapsibleDescription } from 'app/components/common/CollapsibleDescription/CollapsibleDescription'
 import { useI18n } from 'app/hooks/useI18n'
 import { Dataset } from 'app/types/gql/genericTypes'
 import { getTableData } from 'app/utils/table'
@@ -66,14 +67,17 @@ export function SampleAndExperimentConditionsTable({
     {
       label: t('samplePreparation'),
       values: [dataset.samplePreparation ?? ''],
+      renderValue: (value: string) => <CollapsibleDescription text={value} />,
     },
     {
       label: t('gridPreparation'),
       values: [dataset.gridPreparation ?? ''],
+      renderValue: (value: string) => <CollapsibleDescription text={value} />,
     },
     {
       label: t('otherSetup'),
       values: [dataset.otherSetup ?? ''],
+      renderValue: (value: string) => <CollapsibleDescription text={value} />,
     },
   )
 

--- a/frontend/packages/data-portal/app/components/Run/ObjectOverview.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ObjectOverview.tsx
@@ -7,11 +7,14 @@ import { useI18n } from 'app/hooks/useI18n'
 import { useRunById } from 'app/hooks/useRunById'
 
 export function ObjectOverview() {
-  const { objectNames, annotatedObjectsData, identifiedObjectsData } =
-    useRunById()
+  const { annotatedObjectsData, identifiedObjectsData } = useRunById()
   const { t } = useI18n()
 
   const identifiedObjectNames = identifiedObjectsData
+    .map((obj) => obj?.objectName)
+    .filter((name): name is string => Boolean(name))
+
+  const annotatedObjectNames = annotatedObjectsData
     .map((obj) => obj?.objectName)
     .filter((name): name is string => Boolean(name))
 
@@ -25,7 +28,9 @@ export function ObjectOverview() {
       objectDescription?: string | null
     },
   ) => ({
-    id: objectName.toLowerCase().replace(/\s+/g, '-'),
+    // Suffix with the index so distinct objects that share a name (e.g. same
+    // name with different descriptions) get unique React keys.
+    id: `${objectName.toLowerCase().replace(/\s+/g, '-')}-${index}`,
     title: `Object ${index}`,
     data: [
       {
@@ -48,46 +53,33 @@ export function ObjectOverview() {
       },
     ],
   })
+  // Each object is identified by all 4 fields (name, id, state, description),
+  // so we iterate the deduped object rows directly — this keeps each row's own
+  // description/state on its card and counts distinct objects (not just names).
+
   // Verified Objects Annotated = Objects present in BOTH identifiedObjects and annotatedObjects
-  const verifiedAnnotatedObjects = objectNames
+  const verifiedAnnotatedObjects = annotatedObjectsData
     .filter(
-      (name): name is string =>
-        Boolean(name) && identifiedObjectNames.includes(name),
+      (obj) =>
+        obj?.objectName && identifiedObjectNames.includes(obj.objectName),
     )
-    .map((name, index) => {
-      const annotatedData = annotatedObjectsData.find(
-        (obj) => obj?.objectName === name,
-      )
-      const identifiedData = identifiedObjectsData.find(
-        (obj) => obj?.objectName === name,
-      )
-      return createObjectData(name, index + 1, identifiedData || annotatedData)
-    })
+    .map((obj, index) => createObjectData(obj.objectName ?? '', index + 1, obj))
 
   // Verified Objects Unannotated = Objects only in identifiedObjects (not in annotatedObjects)
-  const verifiedNonAnnotatedObjects = identifiedObjectNames
+  const verifiedNonAnnotatedObjects = identifiedObjectsData
     .filter(
-      (name): name is string => Boolean(name) && !objectNames.includes(name),
+      (obj) =>
+        obj?.objectName && !annotatedObjectNames.includes(obj.objectName),
     )
-    .map((name, index) => {
-      const identifiedData = identifiedObjectsData.find(
-        (obj) => obj?.objectName === name,
-      )
-      return createObjectData(name, index + 1, identifiedData)
-    })
+    .map((obj, index) => createObjectData(obj.objectName ?? '', index + 1, obj))
 
   // Unverified Objects Annotated = Objects only in annotatedObjects (not in identifiedObjects)
-  const unverifiedAnnotatedObjects = objectNames
+  const unverifiedAnnotatedObjects = annotatedObjectsData
     .filter(
-      (name): name is string =>
-        Boolean(name) && !identifiedObjectNames.includes(name),
+      (obj) =>
+        obj?.objectName && !identifiedObjectNames.includes(obj.objectName),
     )
-    .map((name, index) => {
-      const annotatedData = annotatedObjectsData.find(
-        (obj) => obj?.objectName === name,
-      )
-      return createObjectData(name, index + 1, annotatedData)
-    })
+    .map((obj, index) => createObjectData(obj.objectName ?? '', index + 1, obj))
 
   const createAccordionHeader = (title: string, tooltipText: string) => (
     <div className="flex items-center gap-sds-xxs">

--- a/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunHeader.tsx
@@ -24,6 +24,7 @@ import {
 import { useRunById } from 'app/hooks/useRunById'
 import { i18n } from 'app/i18n'
 import { TableDataValue } from 'app/types/table'
+import { dedupeObjectsByIdentity } from 'app/utils/annotationObject'
 import { getTiltRangeLabel } from 'app/utils/tiltSeries'
 import { getNeuroglancerUrl } from 'app/utils/url'
 
@@ -35,6 +36,7 @@ export function RunHeader() {
     run,
     processingMethods,
     objectNames,
+    annotatedObjectsData,
     identifiedObjectsData,
     resolutions,
     annotationFilesAggregates,
@@ -283,23 +285,24 @@ export function RunHeader() {
                     {
                       label: '', // Empty label for full-width row
                       inline: true,
-                      values: (() => {
-                        // Create union of objectNames and identifiedObjectNames
-                        const identifiedObjectNames = identifiedObjectsData
-                          .map((obj) => obj?.objectName)
-                          .filter(Boolean) as string[]
-                        const allObjects = new Set([
-                          ...objectNames.filter(Boolean),
-                          ...identifiedObjectNames,
+                      values: (() =>
+                        // Union of annotated + identified objects. An object's
+                        // identity is all 4 fields (name, id, state,
+                        // description), so a name can legitimately repeat when
+                        // its description/state differ.
+                        dedupeObjectsByIdentity([
+                          ...annotatedObjectsData,
+                          ...identifiedObjectsData,
                         ])
-                        return Array.from(allObjects).sort()
-                      })(),
+                          .map((object) => object.objectName)
+                          .filter((name): name is string => Boolean(name))
+                          .sort())(),
                       fullWidth: true,
                       renderValues: (values: TableDataValue[]) => (
                         <div className="[&_li]:inline-flex [&_li]:items-center">
                           <CollapsibleList
-                            entries={values.map((value) => ({
-                              key: value.toString(),
+                            entries={values.map((value, index) => ({
+                              key: `${value.toString()}-${index}`,
                               entry: (
                                 <span className="flex items-center gap-[2px]">
                                   {value.toString()}
@@ -310,7 +313,7 @@ export function RunHeader() {
                               ),
                             }))}
                             inlineVariant
-                            collapseAfter={undefined}
+                            collapseAfter={5}
                           />
                         </div>
                       ),

--- a/frontend/packages/data-portal/app/hooks/useRunById.ts
+++ b/frontend/packages/data-portal/app/hooks/useRunById.ts
@@ -4,6 +4,7 @@ import {
   Annotation_File_Shape_Type_Enum,
   GetRunByIdV2Query,
 } from 'app/__generated_v2__/graphql'
+import { dedupeObjectsByIdentity } from 'app/utils/annotationObject'
 import { getAdditionalContributingDepositions } from 'app/utils/deposition'
 import { isDefined } from 'app/utils/nullish'
 
@@ -40,19 +41,24 @@ export function useRunById() {
     return t2.id - t1.id
   })
 
-  const annotatedObjectsData =
+  // An object's identity is determined by all 4 fields (name, id, state,
+  // description). The query already groups by these, but dedupe defensively so
+  // every consumer sees a consistent, exact-duplicate-free list.
+  const annotatedObjectsData = dedupeObjectsByIdentity(
     v2.uniqueObjectNames.aggregate
       ?.map((aggregate) => aggregate.groupBy)
-      .filter(isDefined) ?? []
+      .filter(isDefined) ?? [],
+  )
 
   const objectNames = annotatedObjectsData
     .map((obj) => obj?.objectName)
     .filter(isDefined)
 
-  const identifiedObjectsData =
+  const identifiedObjectsData = dedupeObjectsByIdentity(
     v2.identifiedObjectNames.aggregate
       ?.map((aggregate) => aggregate.groupBy)
-      .filter(isDefined) ?? []
+      .filter(isDefined) ?? [],
+  )
 
   const objectShapeTypes =
     v2.uniqueShapeTypes.aggregate

--- a/frontend/packages/data-portal/app/utils/annotationObject.test.ts
+++ b/frontend/packages/data-portal/app/utils/annotationObject.test.ts
@@ -1,0 +1,75 @@
+import {
+  dedupeObjectsByIdentity,
+  getObjectIdentityKey,
+} from './annotationObject'
+
+describe('getObjectIdentityKey()', () => {
+  it('produces the same key only when all four fields match', () => {
+    const base = {
+      objectName: 'membrane',
+      objectId: 'GO:0016020',
+      objectState: null,
+      objectDescription: 'Lipid bilayer',
+    }
+
+    expect(getObjectIdentityKey(base)).toBe(getObjectIdentityKey({ ...base }))
+    expect(getObjectIdentityKey(base)).not.toBe(
+      getObjectIdentityKey({ ...base, objectDescription: '' }),
+    )
+    expect(getObjectIdentityKey(base)).not.toBe(
+      getObjectIdentityKey({ ...base, objectId: 'GO:0000001' }),
+    )
+  })
+
+  it('treats nullish and missing fields consistently', () => {
+    expect(getObjectIdentityKey({ objectName: 'a' })).toBe(
+      getObjectIdentityKey({
+        objectName: 'a',
+        objectId: null,
+        objectState: undefined,
+        objectDescription: null,
+      }),
+    )
+  })
+})
+
+describe('dedupeObjectsByIdentity()', () => {
+  it('removes only entries matching on all four fields', () => {
+    const objects = [
+      {
+        objectName: 'membrane',
+        objectId: 'GO:0016020',
+        objectDescription: 'x',
+      },
+      {
+        objectName: 'membrane',
+        objectId: 'GO:0016020',
+        objectDescription: 'x',
+      }, // exact dup -> dropped
+      { objectName: 'membrane', objectId: 'GO:0016020', objectDescription: '' }, // diff desc -> kept
+      {
+        objectName: 'ribosome',
+        objectId: 'GO:0005840',
+        objectDescription: 'x',
+      },
+    ]
+
+    const result = dedupeObjectsByIdentity(objects)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((o) => o.objectDescription)).toEqual(['x', '', 'x'])
+  })
+
+  it('preserves first occurrence and original ordering', () => {
+    const objects = [
+      { objectName: 'b' },
+      { objectName: 'a' },
+      { objectName: 'b' },
+    ]
+
+    expect(dedupeObjectsByIdentity(objects).map((o) => o.objectName)).toEqual([
+      'b',
+      'a',
+    ])
+  })
+})

--- a/frontend/packages/data-portal/app/utils/annotationObject.ts
+++ b/frontend/packages/data-portal/app/utils/annotationObject.ts
@@ -1,0 +1,45 @@
+/**
+ * Identity of an annotated / identified object.
+ *
+ * An object's uniqueness is determined by ALL of these four fields. Two entries
+ * that match on name, ontology ID, state, AND description represent the same
+ * object; differing on any one of them makes them distinct objects.
+ */
+export interface AnnotationObjectIdentity {
+  objectName?: string | null
+  objectId?: string | null
+  objectState?: string | null
+  objectDescription?: string | null
+}
+
+export function getObjectIdentityKey(object: AnnotationObjectIdentity): string {
+  // JSON encoding is used so the four fields combine into an unambiguous key
+  // (no separator can collide with values, and null/undefined are preserved).
+  return JSON.stringify([
+    object.objectName ?? null,
+    object.objectId ?? null,
+    object.objectState ?? null,
+    object.objectDescription ?? null,
+  ])
+}
+
+/**
+ * Remove entries that match on all four identity fields, preserving the first
+ * occurrence and original ordering.
+ */
+export function dedupeObjectsByIdentity<T extends AnnotationObjectIdentity>(
+  objects: T[],
+): T[] {
+  const seen = new Set<string>()
+
+  return objects.filter((object) => {
+    const key = getObjectIdentityKey(object)
+
+    if (seen.has(key)) {
+      return false
+    }
+
+    seen.add(key)
+    return true
+  })
+}


### PR DESCRIPTION
Runs with many annotated objects (the incoming CryoSiam dataset) overflow
several metadata views that render unbounded lists, and the run's object count
was reported inconsistently between views. This PR collapses the overflowing
lists and unifies how an annotated object's identity (and therefore its count)
is determined.

## Changes

- Run header "Objects" — was rendering the full inline list (all objects);
  now collapses to 5 with a "Show N more" toggle.
- Related Databases / Publications — `DatabaseEntryList` now renders through
  `CollapsibleList` (collapses after 5), fixing the no-collapse lists in the
  run, dataset, tomogram, and deposition metadata drawers.
- Sample & experiment conditions — `samplePreparation`, `gridPreparation`,
  and `otherSetup` now use `CollapsibleDescription` (3-line clamp + show
  more/less), matching the deposition drawer and the dataset description field.
- Object counts consolidated — an object's identity is now defined by all
  four fields (name, id, state, description) in one shared helper
  (`utils/annotationObject.ts`). The run header and the Object Overview tab now
  report the same count, and `useRunById` dedupes object data consistently.
- Object Overview bug fix — cards previously looked up data with
  `find()`-by-name, so distinct objects sharing a name showed the *first*
  match's description. Each card now renders its own description/state, with
  unique React keys.
- New unit tests for `getObjectIdentityKey` / `dedupeObjectsByIdentity`
  (`annotationObject.test.ts`); existing `DatabaseEntry` tests still pass
- Verified locally against CryoSiam dataset `10490`: header and Object Overview both report
  127 objects; long metadata lists collapse as expected.