### PR TITLE
fix: queries to check for whether frames and alignment metadata is available

### DIFF
--- a/frontend/packages/data-portal/app/graphql/fragments/getDataContentsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDataContentsV2.server.ts
@@ -7,12 +7,12 @@ export const GET_DATA_CONTENTS_FRAGMENT = gql(`
         count
       }
     }
-    framesAggregate {
+    framesAggregate(where: {httpsFramePath: {_is_null: false}}) {
       aggregate {
         count
       }
     }
-    alignmentsAggregate {
+    alignmentsAggregate(where: {alignmentMethod: {_is_null: false}}) {
       aggregate {
         count
       }


### PR DESCRIPTION
The dataset and deposition **contents summary** report **Alignment** and **Frames** as
"Available" even when a run has no real alignment/frame data. This fixes that by filtering
out the auto-generated dummy records, matching what the run page already does.

## Background — why dummy records exist

The `cryoet-data-portal-backend` import pipeline auto-creates placeholder alignments and
frames even when none were submitted:

- **Dummy alignment** — a default identity alignment is injected per run even when the
  ingestion config has no `alignments` block:
  - finder falls back to a default when no source matches —
    [`base_importer.py#L163-L178`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/ingestion_tools/scripts/importers/base_importer.py#L163-L178)
  - the default = identity matrix, `is_portal_standard=False`, `method_type="undefined"` —
    [`alignment.py#L150-L174`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/ingestion_tools/scripts/importers/alignment.py#L150-L174)
  - at DB import `"undefined"` → `NULL` —
    [`db_import/.../alignment.py#L48-L51`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/apiv2/db_import/importers/alignment.py#L48-L51)
  - **DB signature:** `alignment_method IS NULL`

- **Dummy frames** — a `frames: [literal: default]` source produces one frame row per tilt
  section with no file:
  - file copy skipped for a default source —
    [`frame.py#L30-L37`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/ingestion_tools/scripts/importers/frame.py#L30-L37)
  - one null-path row per section emitted anyway —
    [`frame.py#L69-L90`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/ingestion_tools/scripts/importers/frame.py#L69-L90)
  - null path → null DB columns —
    [`db_import/.../frame.py#L31-L34`](https://github.com/chanzuckerberg/cryoet-data-portal-backend/blob/29d5a644eac476225ce6607a628fe90afd83d824/apiv2/db_import/importers/frame.py#L31-L34)
  - **DB signature:** `https_frame_path IS NULL`

The run page already excludes these (it filters `alignmentMethod: {_is_null: false}` and
`httpsFramePath: {_is_null: false}`), but the dataset/deposition contents summary used
unfiltered aggregate counts — so the two views disagreed.

## Change

Apply the same filters in the shared `DataContents` fragment
(`app/graphql/fragments/getDataContentsV2.server.ts`):

```graphql
framesAggregate(where: {httpsFramePath: {_is_null: false}}) { aggregate { count } }
alignmentsAggregate(where: {alignmentMethod: {_is_null: false}}) { aggregate { count } }
```

`getDataContents` (`app/utils/deposition.ts`) consumes the counts unchanged, so the dataset
page contents summary and the deposition page now stop counting dummy records.

## Verification

Example: dataset 10491 / run 36042 on staging, whose only alignment & frames are dummies.

Before (unfiltered) vs after (filtered):

```
alignmentsAggregate(runId:36042)                          -> count 1   # was shown "Available"
alignments(runId:36042, alignmentMethod _is_null:false)   -> []        # now "Not Submitted"

framesAggregate(runId:36042)                              -> count 61  # was shown "Available"
framesAggregate(runId:36042, httpsFramePath _is_null:false) -> count 0 # now "Not Submitted"
```

- `pnpm data-portal build:codegen` — regenerates `__generated_v2__` cleanly
- `pnpm data-portal type-check` — passes
