### PR TITLE
fix: populate deposition method links for all annotation methods

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/MethodLinks/common.tsx
@@ -45,11 +45,17 @@ export function generateMethodLinkProps(
   links: Array<Pick<AnnotationMethodLink, 'name' | 'linkType' | 'link'>>,
 ): MethodLinkProps[] {
   return links
-    .sort(
-      (a, b) =>
+    .slice()
+    .sort((a, b) => {
+      const typeOrder =
         METHOD_LINK_TYPE_ORDER.indexOf(getLinkType(a)) -
-        METHOD_LINK_TYPE_ORDER.indexOf(getLinkType(b)),
-    )
+        METHOD_LINK_TYPE_ORDER.indexOf(getLinkType(b))
+
+      // Tiebreak by name so ordering is deterministic within a link type.
+      return typeOrder !== 0
+        ? typeOrder
+        : (a.name ?? '').localeCompare(b.name ?? '')
+    })
     .map((link) => ({
       title: link.name ?? '',
       url: link.link ?? '',

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -75,16 +75,6 @@ const GET_DEPOSITION_BASE_DATA = gql(`
             annotationMethod
             annotationSoftware
             methodType
-            methodLinks {
-              edges {
-                node {
-                  id
-                  link
-                  linkType
-                  name
-                }
-              }
-            }
           }
         }
       }
@@ -125,6 +115,22 @@ const GET_DEPOSITION_BASE_DATA = gql(`
             samplePreparation
             sampleType
             gridPreparation
+          }
+        }
+      }
+    }
+
+    # Distinct method links per method via aggregate groupBy, so the set is complete
+    # regardless of annotation pagination (depositions can have tens of thousands).
+    annotationMethodLinks: annotationMethodLinksAggregate(where: { annotation: { depositionId: { _eq: $id } } }) {
+      aggregate {
+        count
+        groupBy {
+          link
+          linkType
+          name
+          annotation {
+            annotationMethod
           }
         }
       }

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -17,7 +17,6 @@ export interface AnnotationMethodMetadata {
   methodType?: Annotation_Method_Type_Enum
   count: number
   methodLinks: Array<{
-    id: number // internal use only, for sorting
     name?: string
     linkType?: Annotation_Method_Link_Type_Enum
     link?: string
@@ -105,38 +104,33 @@ export function useDepositionById() {
       if (meta.methodType === undefined && node.methodType != null) {
         meta.methodType = node.methodType
       }
-
-      for (const methodLinkEdge of node.methodLinks?.edges ?? []) {
-        const { id, link, name, linkType } = methodLinkEdge.node
-        meta.methodLinks.push({
-          id,
-          name: name ?? undefined,
-          linkType: linkType ?? undefined,
-          link: link ?? undefined,
-        })
-      }
     }
 
-    // Deduplicate and sort method links
-    for (const [method, metadata] of annotationMethodToMetadata) {
-      const unique = new Map<string, (typeof metadata.methodLinks)[0]>()
-      for (const link of metadata.methodLinks) {
-        const key = JSON.stringify([
-          method,
-          link.link,
-          link.name,
-          link.linkType,
-        ])
-        // Keep only the smallest id per unique key (to preserve original ordering)
-        if (!unique.has(key) || link.id < unique.get(key)!.id) {
-          unique.set(key, link)
+    // Method links come from an aggregate groupBy, so the set is complete and distinct
+    // regardless of annotation pagination.
+    for (const aggregate of v2.annotationMethodLinks?.aggregate ?? []) {
+      const { groupBy } = aggregate
+      const annotationMethod = groupBy?.annotation?.annotationMethod
+      if (annotationMethod == null) continue
+
+      let meta = annotationMethodToMetadata.get(annotationMethod)
+      if (!meta) {
+        meta = {
+          annotationSoftware: undefined,
+          methodType: undefined,
+          count: 0,
+          methodLinks: [],
         }
+        annotationMethodToMetadata.set(annotationMethod, meta)
       }
 
-      metadata.methodLinks = Array.from(unique.values()).sort(
-        (a, b) => a.id - b.id,
-      )
+      meta.methodLinks.push({
+        name: groupBy?.name ?? undefined,
+        linkType: groupBy?.linkType ?? undefined,
+        link: groupBy?.link ?? undefined,
+      })
     }
+
     // Convert to sorted array:
     return [...annotationMethodToMetadata.entries()]
       .map(([annotationMethod, metadata]) => ({
@@ -155,7 +149,7 @@ export function useDepositionById() {
             annotationMethodB.methodType ?? Annotation_Method_Type_Enum.Manual,
           ),
       )
-  }, [v2.depositions])
+  }, [v2.depositions, v2.annotationMethodLinks])
 
   const tomogramMethods: TomogramMethodMetadata[] = useMemo(() => {
     const tomogramMethodsData =


### PR DESCRIPTION
## Problem
Method links in the deposition Methods Summary were collected from the deposition's **paginated** `annotations` edges (only the first ~100 rows). For depositions with many annotations, any annotation method whose rows fell outside that first page rendered with **no method links**.

## Fix
Source method links from an `annotationMethodLinksAggregate` `groupBy` (method + link fields), which returns the complete, distinct set regardless of pagination. Drop the now-unused `methodLinks` selection from the paginated edges, remove the `id`-based dedup, and tiebreak link ordering by name for determinism.

## Verification
Verified on deposition 10348 (CryoSiam): all 3 annotation methods now show their 5 links (previously only the first method did). type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
