### PR TITLE
fix: count annotation shapes in deposition method summary

### DIFF
--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -60,15 +60,6 @@ const GET_DEPOSITION_BASE_DATA = gql(`
           }
         }
       }
-      annotationMethodCounts: annotationsAggregate {
-        aggregate {
-          count
-          groupBy {
-            annotationMethod
-          }
-        }
-      }
-
       annotations(where: {depositionId: {_eq: $id}}) {
         edges {
           node {
@@ -125,6 +116,19 @@ const GET_DEPOSITION_BASE_DATA = gql(`
             samplePreparation
             sampleType
             gridPreparation
+          }
+        }
+      }
+    }
+
+    # Method counts use annotation SHAPES (not parent annotations) so they match
+    # "# annotations" shown elsewhere on the portal and add up to the total.
+    annotationMethodCounts: annotationShapesAggregate(where: { annotation: { depositionId: { _eq: $id } } }) {
+      aggregate {
+        count
+        groupBy {
+          annotation {
+            annotationMethod
           }
         }
       }

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -65,10 +65,10 @@ export function useDepositionById() {
       Omit<AnnotationMethodMetadata, 'annotationMethod'>
     >()
 
-    // Authoritative method list + counts from aggregate (annotations.edges is paginated)
-    for (const aggregate of v2.depositions[0]?.annotationMethodCounts
-      ?.aggregate ?? []) {
-      const annotationMethod = aggregate.groupBy?.annotationMethod
+    // Authoritative method list + SHAPE counts (annotations.edges is paginated). Counts
+    // use annotation shapes so they match "# annotations" shown elsewhere and add up.
+    for (const aggregate of v2.annotationMethodCounts?.aggregate ?? []) {
+      const annotationMethod = aggregate.groupBy?.annotation?.annotationMethod
       if (annotationMethod == null) {
         continue
       }
@@ -155,7 +155,7 @@ export function useDepositionById() {
             annotationMethodB.methodType ?? Annotation_Method_Type_Enum.Manual,
           ),
       )
-  }, [v2.depositions])
+  }, [v2.depositions, v2.annotationMethodCounts])
 
   const tomogramMethods: TomogramMethodMetadata[] = useMemo(() => {
     const tomogramMethodsData =


### PR DESCRIPTION
## Problem
The Methods Summary "Annotations" column counted **parent annotation records** (`annotationsAggregate` grouped by `annotationMethod`), while the rest of the portal counts **annotation shapes**. The per-method numbers therefore didn't reconcile with the totals shown elsewhere (e.g. summed to 39,347 vs the 75,934 shapes total for deposition 10348).

## Fix
Count annotation **shapes** grouped by method (`annotationShapesAggregate` grouped by `annotation.annotationMethod`) so the per-method counts use the same unit as the rest of the portal and add up.

## Verification
Deposition 10348: rows now read 66,660 + 2,760 + 6,514 = 75,934, matching the total. type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
