### PR TITLE
fix: show correct total annotations in deposition metadata drawer

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/DepositionMetadataDrawer/AnnotationsSummaryMetadataTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DepositionMetadataDrawer/AnnotationsSummaryMetadataTable.tsx
@@ -14,18 +14,14 @@ export function AnnotationsSummaryMetadataTable({
 }) {
   const { t } = useI18n()
 
-  const { deposition } = useDepositionById()
+  const { annotationsCount } = useDepositionById()
   const { organismNames, objectNames, objectShapeTypes } =
     useDatasetsFilterData()
 
   const annotationsSummaryMetadata = getTableData(
     {
       label: t('annotationsTotal'),
-      values: [
-        (
-          deposition.annotationsAggregate?.aggregate?.[0]?.count ?? 0
-        ).toLocaleString(),
-      ],
+      values: [annotationsCount.toLocaleString()],
     },
 
     {


### PR DESCRIPTION
## Problem
The deposition metadata drawer's Annotations Summary read `deposition.annotationsAggregate.aggregate[0].count` — a **dataset-grouped** aggregate — so the "Total annotations" row showed only the **first dataset's** count instead of the deposition total.

## Fix
Use the deposition's total annotation-shape count (`annotationsCount` from `useDepositionById`) instead.

## Verification
Deposition 10348: shows 75,934 (was 37,786, the first dataset's count). type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
