### PR TITLE
fix: populate annotated organisms/objects/shape types in deposition drawer

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/DepositionMetadataDrawer/AnnotationsSummaryMetadataTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DepositionMetadataDrawer/AnnotationsSummaryMetadataTable.tsx
@@ -1,7 +1,6 @@
 import { Annotation_File_Shape_Type_Enum } from 'app/__generated_v2__/graphql'
 import { AccordionMetadataTable } from 'app/components/AccordionMetadataTable'
 import { CollapsibleList } from 'app/components/CollapsibleList'
-import { useDatasetsFilterData } from 'app/hooks/useDatasetsFilterData'
 import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useI18n } from 'app/hooks/useI18n'
 import { checkExhaustive } from 'app/types/utils'
@@ -14,9 +13,8 @@ export function AnnotationsSummaryMetadataTable({
 }) {
   const { t } = useI18n()
 
-  const { deposition } = useDepositionById()
-  const { organismNames, objectNames, objectShapeTypes } =
-    useDatasetsFilterData()
+  const { deposition, annotatedOrganisms, annotatedObjects, objectShapeTypes } =
+    useDepositionById()
 
   const annotationsSummaryMetadata = getTableData(
     {
@@ -33,7 +31,7 @@ export function AnnotationsSummaryMetadataTable({
       values: [],
       renderValue: () => (
         <CollapsibleList
-          entries={organismNames.map((name: string) => ({
+          entries={annotatedOrganisms.map((name: string) => ({
             key: name,
             entry: name,
           }))}
@@ -48,7 +46,7 @@ export function AnnotationsSummaryMetadataTable({
       values: [],
       renderValue: () => (
         <CollapsibleList
-          entries={objectNames.map((name: string) => ({
+          entries={annotatedObjects.map((name: string) => ({
             key: name,
             entry: name,
           }))}

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -47,19 +47,6 @@ const GET_DEPOSITION_BASE_DATA = gql(`
           }
         }
       }
-      annotationsAggregate {
-        aggregate {
-          count
-
-          groupBy {
-            run {
-              dataset {
-                id
-              }
-            }
-          }
-        }
-      }
       annotationMethodCounts: annotationsAggregate {
         aggregate {
           count

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -130,6 +130,37 @@ const GET_DEPOSITION_BASE_DATA = gql(`
       }
     }
 
+    # Distinct organisms / annotated objects / shape types for this deposition, for the
+    # metadata drawer's Annotations Summary.
+    distinctAnnotatedOrganisms: runsAggregate(where: { annotations: { depositionId: { _eq: $id } } }) {
+      aggregate {
+        count
+        groupBy {
+          dataset {
+            organismName
+          }
+        }
+      }
+    }
+
+    distinctAnnotatedObjects: annotationsAggregate(where: { depositionId: { _eq: $id } }) {
+      aggregate {
+        count
+        groupBy {
+          objectName
+        }
+      }
+    }
+
+    distinctObjectShapeTypes: annotationShapesAggregate(where: { annotation: { depositionId: { _eq: $id } } }) {
+      aggregate {
+        count
+        groupBy {
+          shapeType
+        }
+      }
+    }
+
     annotationsCount: annotationShapesAggregate(where: {
       annotation: {
         depositionId: {

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTypedLoaderData } from 'remix-typedjson'
 
 import {
+  Annotation_File_Shape_Type_Enum,
   Annotation_Method_Link_Type_Enum,
   Annotation_Method_Type_Enum,
   type GetDepositionAnnotationsQuery,
@@ -10,6 +11,7 @@ import {
   type GetDepositionTomogramsQuery,
 } from 'app/__generated_v2__/graphql'
 import { METHOD_TYPE_ORDER } from 'app/constants/methodTypes'
+import { isDefined } from 'app/utils/nullish'
 
 export interface AnnotationMethodMetadata {
   annotationMethod: string
@@ -207,11 +209,49 @@ export function useDepositionById() {
         .sort((a, b) => b.count - a.count)
     }, [v2.experimentalConditionsCounts])
 
+  const annotatedOrganisms = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          v2.distinctAnnotatedOrganisms?.aggregate
+            ?.map((aggregate) => aggregate.groupBy?.dataset?.organismName)
+            .filter(isDefined) ?? [],
+        ),
+      ).sort((a, b) => a.localeCompare(b)),
+    [v2.distinctAnnotatedOrganisms],
+  )
+
+  const annotatedObjects = useMemo(
+    () =>
+      (
+        v2.distinctAnnotatedObjects?.aggregate
+          ?.map((aggregate) => aggregate.groupBy?.objectName)
+          .filter(isDefined) ?? []
+      ).sort((a, b) => a.localeCompare(b)),
+    [v2.distinctAnnotatedObjects],
+  )
+
+  const objectShapeTypes = useMemo(
+    () =>
+      v2.distinctObjectShapeTypes?.aggregate
+        ?.map((aggregate) => aggregate.groupBy?.shapeType)
+        .filter(isDefined)
+        .filter((shapeType): shapeType is Annotation_File_Shape_Type_Enum =>
+          Object.values<string>(Annotation_File_Shape_Type_Enum).includes(
+            shapeType,
+          ),
+        ) ?? [],
+    [v2.distinctObjectShapeTypes],
+  )
+
   return {
     annotationMethods,
     tomogramMethods,
     acquisitionMethods,
     experimentalConditions,
+    annotatedOrganisms,
+    annotatedObjects,
+    objectShapeTypes,
     annotations,
     tomograms,
     allRuns: expandedData?.allRuns,


### PR DESCRIPTION
## Problem
The deposition metadata drawer's Annotations Summary sourced its **Annotated Organisms / Annotated Objects / Object Shape Types** lists from `useDatasetsFilterData`, whose `distinct*` aggregates only exist on the **datasets** page query. On the deposition page those fields are `undefined`, so the rows were always blank.

## Fix
Add deposition-scoped `distinctAnnotatedOrganisms` / `distinctAnnotatedObjects` / `distinctObjectShapeTypes` aggregates to the deposition query, expose them from `useDepositionById` (objects and organisms sorted alphabetically), and consume them in the drawer.

## Verification
Deposition 10348 loader returns organisms `[not_reported]`, 4 shape types, and 151 objects (previously all empty). type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
