### PR TITLE
fix: correct deposition table pagination page size

### DIFF
--- a/frontend/packages/data-portal/app/routes/depositions.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/depositions.$id.tsx
@@ -11,12 +11,13 @@ import { DepositionTableSection } from 'app/components/Deposition/DepositionTabl
 import { NoResultsRenderer } from 'app/components/Deposition/NoResultsRenderer'
 import { TablePageLayout } from 'app/components/TablePageLayout'
 import { TableCountHeader } from 'app/components/TablePageLayout/TableCountHeader'
-import { MAX_PER_ACCORDION_GROUP } from 'app/constants/pagination'
+import { MAX_PER_ACCORDION_GROUP, MAX_PER_PAGE } from 'app/constants/pagination'
 import { QueryParams } from 'app/constants/query'
 import { useActiveDepositionDataType } from 'app/hooks/useActiveDepositionDataType'
 import { useDepositionPageState } from 'app/hooks/useDepositionPageState'
 import { useGroupBy } from 'app/hooks/useGroupBy'
 import { useI18n } from 'app/hooks/useI18n'
+import { GroupByOption } from 'app/types/depositionTypes'
 import { getTableCounts } from 'app/utils/deposition/countSelectors'
 import { fetchDepositionData } from 'app/utils/deposition/dataFetchers'
 import { getCountLabelI18nKey } from 'app/utils/deposition/labelSelectors'
@@ -99,6 +100,12 @@ export default function DepositionByIdPage() {
     groupBy,
   })
 
+  // The ungrouped view server-paginates the flat shape/tomogram table by MAX_PER_PAGE;
+  // grouped views page accordion groups by MAX_PER_ACCORDION_GROUP. The pagination page
+  // size must match the active view's, or the page count overruns the available data.
+  const pageSize =
+    groupBy === GroupByOption.None ? MAX_PER_PAGE : MAX_PER_ACCORDION_GROUP
+
   return (
     <TablePageLayout
       title={t('depositedData')}
@@ -116,7 +123,7 @@ export default function DepositionByIdPage() {
           totalCount,
           filteredCount,
           filterPanel: <DepositionFilters />,
-          pageSize: MAX_PER_ACCORDION_GROUP,
+          pageSize,
         },
       ]}
       drawers={<DepositionMetadataDrawer />}


### PR DESCRIPTION
## Problem
The ungrouped deposition view server-paginates the flat annotation-shape / tomogram table by `MAX_PER_PAGE` (20), but the page component sized the pagination control with `MAX_PER_ACCORDION_GROUP` (10). The control advertised roughly twice as many pages as exist and the back half rendered **empty** (e.g. 7594 pages vs the real 3797 for annotations; 160 vs 80 for tomograms; out-of-range pages redirected to page 1).

## Fix
Choose the pagination page size based on the active view: `MAX_PER_PAGE` for the ungrouped (flat) view, `MAX_PER_ACCORDION_GROUP` for the grouped accordion views.

## Verification
Deposition 10348: last page is now 3797 (annotations) / 80 (tomograms) and contains data; previously-empty pages redirect correctly. type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
