### PR TITLE
fix: prevent metadata drawer horizontal overflow when scrollbar appears

### DIFF
--- a/frontend/packages/data-portal/app/components/MetadataDrawer.tsx
+++ b/frontend/packages/data-portal/app/components/MetadataDrawer.tsx
@@ -113,8 +113,6 @@ export function MetadataDrawer({
     <Drawer open={isOpen} onClose={handleClose}>
       <div
         className={cns(
-          // min-w-0 lets this flex child shrink when a vertical scrollbar narrows the
-          // drawer, so content reflows instead of forcing a horizontal scrollbar.
           'flex flex-col flex-auto min-w-0',
           isTopBannerVisible ? 'mt-10' : 'mt-0',
         )}

--- a/frontend/packages/data-portal/app/components/MetadataDrawer.tsx
+++ b/frontend/packages/data-portal/app/components/MetadataDrawer.tsx
@@ -113,7 +113,9 @@ export function MetadataDrawer({
     <Drawer open={isOpen} onClose={handleClose}>
       <div
         className={cns(
-          'flex flex-col flex-auto',
+          // min-w-0 lets this flex child shrink when a vertical scrollbar narrows the
+          // drawer, so content reflows instead of forcing a horizontal scrollbar.
+          'flex flex-col flex-auto min-w-0',
           isTopBannerVisible ? 'mt-10' : 'mt-0',
         )}
         data-testid={TestIds.MetadataDrawer}
@@ -166,7 +168,7 @@ export function MetadataDrawer({
 
         <div
           className={cns(
-            'flex flex-col flex-auto',
+            'flex flex-col flex-auto min-w-0',
             'px-sds-xl pt-sds-xl pb-sds-xxl',
 
             drawer.activeTab === MetadataTab.Metadata &&


### PR DESCRIPTION
## Problem
When the metadata drawer content is tall enough to need a vertical scrollbar, the scrollbar narrows the fixed-width drawer (490 → ~475px). The drawer's flex content containers default to `min-width: auto`, so they refuse to shrink below their content's min-content (~478px) and overflow horizontally by a few px, producing an unwanted horizontal scrollbar. (Only reproduces where scrollbars consume layout width — Windows, or macOS "always show scrollbars".)

## Fix
Add `min-w-0` to the drawer's `flex flex-auto` content containers so they shrink with the paper and the content reflows instead of overflowing.

## Verification
Simulating the scrollbar squeeze (paper forced to 475px), overflow goes 3px → 0; reverting `min-w-0` reproduces the 3px. type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
