### PR TITLE
fix: don't render a broken deposition link for empty additional contributions

### DIFF
--- a/frontend/packages/data-portal/app/components/Dataset/DatasetMetadataTable.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/DatasetMetadataTable.tsx
@@ -153,10 +153,16 @@ export function DatasetMetadataTable({
     {
       label: t('additionalContributions'),
       values: additionalContributingDepositions,
-      renderValues(values) {
+      // Use the source list directly: getTableData substitutes ['--'] for an empty
+      // array, which would otherwise render a broken "CZCDP---" / /depositions/-- link.
+      renderValues() {
+        if (additionalContributingDepositions.length === 0) {
+          return '--'
+        }
+
         return (
           <ul>
-            {values.map((value) => (
+            {additionalContributingDepositions.map((value) => (
               <li key={value}>
                 <Link
                   className="text-light-sds-color-primitive-blue-500"


### PR DESCRIPTION
## Problem
On a dataset/run with **no** additional contributing depositions, the metadata drawer's "Additional Contributions" row showed `CZCDP---` linking to `/depositions/--` (a broken link).

## Cause
`getTableData` substitutes `['--']` for an empty `values` array (its placeholder for "no data"). The `additionalContributions` renderer mapped that placeholder straight into a deposition link (`{IdPrefix.Deposition}-{value}` → `CZCDP---`, `to={/depositions/${value}}` → `/depositions/--`).

## Fix
Render from the source `additionalContributingDepositions` list directly (in `DatasetMetadataTable`, used by both the dataset and run drawers) and show `--` when it's empty, instead of mapping the `['--']` placeholder into a link.

## Verification
type-check + lint pass. A dataset with no additional contributions now shows `--`; one with contributions still shows the deposition links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
