### PR TITLE
fix: reduce neuroglancer viewer camera-drag lag on large states

### DIFF
--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -2,6 +2,7 @@ import { Button } from '@czi-sds/components'
 import { SnackbarCloseReason } from '@mui/material/Snackbar'
 import {
   currentNeuroglancerState,
+  flushStateToUrl,
   NeuroglancerAwareIframe,
   NeuroglancerState,
   NeuroglancerWrapper,
@@ -306,6 +307,7 @@ export function ViewerPage({
   }
 
   const handleShareClick = () => {
+    flushStateToUrl()
     navigator.clipboard
       .writeText(window.location.href)
       .then(() => {

--- a/frontend/packages/neuroglancer/src/NeuroglancerWrapper.tsx
+++ b/frontend/packages/neuroglancer/src/NeuroglancerWrapper.tsx
@@ -7,6 +7,7 @@ import {
   newSuperState,
   updateNeuroglancerConfigInSuperstate,
   parseState,
+  setLiveSuperState,
   type ResolvedSuperState,
   NeuroglancerAwareIframe,
 } from './utils'
@@ -17,6 +18,15 @@ interface NeuroglancerWrapperProps {
   compressURL?: boolean
   className?: string
 }
+
+// How long the camera/state must be quiet (no synchash) before we write the
+// gzip-compressed hash to the URL.
+const COMPRESS_DEBOUNCE_MS = 1000
+
+// How long movement must be quiet (no synchash) before the trailing
+// onStateChange fires. The in-memory live state is still updated every frame,
+// so app reads stay fresh regardless.
+const STATE_CHANGE_DEBOUNCE_MS = 1000
 
 const NeuroglancerWrapper = forwardRef<
   NeuroglancerAwareIframe,
@@ -32,6 +42,13 @@ const NeuroglancerWrapper = forwardRef<
     ref,
   ) => {
     const superState = useRef<SuperState>(newSuperState(window.location.hash))
+    const compressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // Held in a ref so the listener effect can mount once; if it re-ran per
+    // render its cleanup would clear the pending compress timer.
+    const onStateChangeRef = useRef(onStateChange)
+    useEffect(() => {
+      onStateChangeRef.current = onStateChange
+    }, [onStateChange])
 
     // Add event listeners for hash changes and iframe messages
     useEffect(() => {
@@ -40,11 +57,15 @@ const NeuroglancerWrapper = forwardRef<
         return () => {}
       }
 
+      // Publish the initial state so app reads are fresh before the first synchash.
+      setLiveSuperState(superState.current)
+
       // main window hash -> iFrame hash sync
       const handleHashChange = () => {
         const hash = window.location.hash
         // First we parse the super state (if there is no super state, one is created empty)
         superState.current = parseSuperState(hash, superState.current)
+        setLiveSuperState(superState.current)
         const state = superState.current
         if (hashIsUncompressed(hash)) {
           // In case we receive a uncompressed hash
@@ -65,29 +86,83 @@ const NeuroglancerWrapper = forwardRef<
         )
       }
 
+      // Expensive (stringify + gzip); debounced to run once after movement
+      // settles, not per frame.
+      const writeStateToUrl = () => {
+        compressTimer.current = null
+        const newHash = encodeState(superState.current, compressURL)
+        if (window.location.hash !== newHash) {
+          history.replaceState(null, '', newHash)
+        }
+      }
+
+      // Leading + trailing debounce: fire at the start of an interaction and
+      // once after it settles, never during a continuous drag.
+      let stateChangeTimer: ReturnType<typeof setTimeout> | null = null
+      let pendingTrailingStateChange = false
+
+      const emitStateChange = () => {
+        onStateChangeRef.current?.({
+          ...superState.current,
+          neuroglancer: parseState(superState.current.neuroglancer),
+        })
+      }
+
+      const scheduleStateChange = () => {
+        if (stateChangeTimer === null) {
+          // Immediately propagate state change on non-continuous actions (clicks, tour).
+          emitStateChange()
+        } else {
+          clearTimeout(stateChangeTimer)
+          pendingTrailingStateChange = true
+        }
+        stateChangeTimer = setTimeout(() => {
+          stateChangeTimer = null
+          if (pendingTrailingStateChange) {
+            pendingTrailingStateChange = false
+            emitStateChange()
+          }
+        }, STATE_CHANGE_DEBOUNCE_MS)
+      }
+
       // iFrame hash -> main window hash sync
       const handleMessage = (event: MessageEvent) => {
         const { type, hash } = event.data
         // When we receive a sync from neuroglancer (iFrame), we know it's uncompressed
         if (type === 'synchash' && window.location.hash !== hash) {
           updateNeuroglancerConfigInSuperstate(superState.current, hash)
-          const newHash = encodeState(superState.current, compressURL)
-          history.replaceState(null, '', newHash)
-          onStateChange?.({
-            ...superState.current,
-            neuroglancer: parseState(superState.current.neuroglancer),
-          })
+          // Cheap ref assignment; no serialize/URL write on the hot path.
+          setLiveSuperState(superState.current)
+          scheduleStateChange()
+          if (compressTimer.current !== null) {
+            clearTimeout(compressTimer.current)
+          }
+          compressTimer.current = setTimeout(writeStateToUrl, COMPRESS_DEBOUNCE_MS)
         }
       }
 
       window.addEventListener('hashchange', handleHashChange)
       window.addEventListener('message', handleMessage)
 
+      // Entry URL is often uncompressed/long; compress it shortly after load
+      // even without movement.
+      compressTimer.current = setTimeout(writeStateToUrl, COMPRESS_DEBOUNCE_MS)
+
       return () => {
         window.removeEventListener('hashchange', handleHashChange)
         window.removeEventListener('message', handleMessage)
+        if (compressTimer.current !== null) {
+          clearTimeout(compressTimer.current)
+          compressTimer.current = null
+        }
+        if (stateChangeTimer !== null) {
+          clearTimeout(stateChangeTimer)
+          stateChangeTimer = null
+        }
+        // Drop the in-memory state so it can't leak across navigation.
+        setLiveSuperState(null)
       }
-    }, [onStateChange, compressURL, ref])
+    }, [compressURL, ref])
 
     return (
       <iframe

--- a/frontend/packages/neuroglancer/src/utils.ts
+++ b/frontend/packages/neuroglancer/src/utils.ts
@@ -109,6 +109,15 @@ const emptySuperState = (config: string): SuperState => {
   }
 }
 
+// In-memory source of truth for the current viewer state, published by the
+// wrapper each frame. Reads below prefer it so they stay fresh while the URL is
+// written lazily; null falls back to parsing window.location.hash.
+let liveSuperState: SuperState | null = null
+
+export const setLiveSuperState = (state: SuperState | null): void => {
+  liveSuperState = state
+}
+
 export const updateState = (
   onStateChange: (state: ResolvedSuperState) => ResolvedSuperState | undefined,
 ) => {
@@ -166,35 +175,56 @@ export function hash2jsonString(hash: string): string {
   return hash
 }
 
-// Helper functions for parsing and encoding state
-export const currentState = (
-  hash = window.location.hash,
-): ResolvedSuperState => {
-  const superState = parseSuperState(hash)
+// Helper functions for parsing and encoding state. Without an explicit hash,
+// these read the live state if published, else parse window.location.hash.
+export const currentState = (hash?: string): ResolvedSuperState => {
+  if (hash === undefined && liveSuperState !== null) {
+    return {
+      ...liveSuperState,
+      neuroglancer: parseState(liveSuperState.neuroglancer),
+    }
+  }
+  const superState = parseSuperState(hash ?? window.location.hash)
   if (superState.neuroglancer) {
     return { ...superState, neuroglancer: parseState(superState.neuroglancer) }
   }
   return { ...superState, neuroglancer: {} }
 }
 
-export const currentNeuroglancerState = (
-  hash = window.location.hash,
-): NeuroglancerState => {
-  const superState = parseState(hash)
+export const currentNeuroglancerState = (hash?: string): NeuroglancerState => {
+  if (hash === undefined && liveSuperState !== null) {
+    return parseState(liveSuperState.neuroglancer)
+  }
+  const superState = parseState(hash ?? window.location.hash)
   if (superState.neuroglancer) {
     return parseState(superState.neuroglancer as string)
   }
   return superState
 }
 
-export const currentSuperState = (hash = window.location.hash) => {
-  return parseSuperState(hash)
+export const currentSuperState = (hash?: string): SuperState => {
+  if (hash === undefined && liveSuperState !== null) {
+    return { ...liveSuperState }
+  }
+  return parseSuperState(hash ?? window.location.hash)
 }
 
 export const commitState = (state: SuperState | ResolvedSuperState) => {
   state.neuroglancer = encodeState(state.neuroglancer, /* compress = */ false)
+  // Sync live state before the (async) hashchange, so reads after a commit are fresh.
+  setLiveSuperState(state as SuperState)
   const newHash = encodeState(state)
   window.location.hash = newHash // This triggers the hashchange listener
+}
+
+// Flush the live state into the URL (compressed) immediately, bypassing the
+// settle debounce — for actions that read window.location.href directly (Share).
+export const flushStateToUrl = (): void => {
+  const superState = liveSuperState ?? parseSuperState(window.location.hash)
+  const newHash = encodeState(superState)
+  if (window.location.hash !== newHash) {
+    window.history.replaceState(null, '', newHash)
+  }
 }
 
 export const parseState = (


### PR DESCRIPTION
Dragging the camera in the Neuroglancer viewer (`/view/runs/$id`) lagged on large viewer states (instance-segmentation / many annotation layers). Every `synchash` from the iframe (~60/s while the camera moves) synchronously serialized the whole state into the URL (`JSON.stringify` + `encodeURIComponent` + `pako.gzip` + `history.replaceState`) and re-rendered `ViewerPage`.

## Changes

- **In-memory source of truth** — the wrapper publishes the latest state to `liveSuperState` on each `synchash` (a cheap reference assignment); `currentState` / `currentNeuroglancerState` / `currentSuperState` read it, falling back to parsing `window.location.hash`. The URL only ever served these reads, which happen on discrete user actions, not per frame.
- **Lazy URL write** — the compressed-hash write is debounced to run once ~1s after movement settles instead of every frame; `flushStateToUrl()` forces it immediately for Share, and the (uncompressed) entry URL is compressed shortly after load.
- **Debounced re-render** — `onStateChange` (the `ViewerPage` re-render + state re-parses) is a leading+trailing debounce: it fires at the start of an interaction and once after it settles, never during a continuous drag.

Reads stay fresh (no stale-URL camera reset) and the shared URL is still compressed.

## Verification

- `pnpm --filter neuroglancer build` + lint and `pnpm data-portal type-check` pass
- Heavy run: drag is smooth, URL compresses after the camera settles, Share copies a compressed URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)