### PR TITLE
fix: strip metadata/tab params when navigating to tomograms

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-3c4df5d
+        tag: sha-f7878c6
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/components/Run/TomogramsSummarySection.tsx
+++ b/frontend/packages/data-portal/app/components/Run/TomogramsSummarySection.tsx
@@ -33,6 +33,8 @@ export function TomogramsSummarySection() {
                 // the table-tab switch stays a real navigation.
                 closeDrawer()
                 setSearchParams((prev) => {
+                  prev.delete(QueryParams.MetadataDrawer)
+                  prev.delete(QueryParams.Tab)
                   prev.set(QueryParams.TableTab, t('tomograms'))
                   return prev
                 })


### PR DESCRIPTION
## Problem

Follow-up to #2091 (metadata drawer perf fix, already merged). @PALLAVIKHEDLE flagged a possible URL-desync in `TomogramsSummarySection`.

When the run metadata drawer is opened via a **deep-link / shared URL / reload** (so `?metadata=run&tab=metadata` came through a real React Router navigation), clicking **"Go to Tomograms"** inside the drawer leaves those params in the address bar and **reopens the drawer on reload**.

## Root cause

The button handler does:

```ts
closeDrawer()                    // clears metadata/tab from the URL via history.replaceState
setSearchParams((prev) => {      // prev is derived from RR's location, which never saw the replaceState
  prev.set(QueryParams.TableTab, t('tomograms'))
  return prev
})
```

`closeDrawer()` writes the URL through `history.replaceState`, which React Router does **not** observe (no `popstate`), so RR's `location` stays stale. The immediately-following `setSearchParams` rebuilds the URL from that stale location — re-adding `metadata` + `tab`. The drawer atoms say "closed" so it looks closed, and `MetadataDrawerUrlSync` only re-seeds on `pathname` change (this is a search-only nav), so the desync sits until a reload re-opens the drawer.

Only reproduces when RR's location actually holds the params (deep-link / reload with the drawer open) — not when the drawer was opened by an in-app click in the same session.

## Fix

Delete the two params inside the `setSearchParams` callback too, so the React Router navigation that switches the table tab also drops them. Idempotent — harmless when they aren't present.

## Repro

1. Open `/runs/<id>?metadata=run&tab=metadata` → drawer opens on the Metadata tab.
2. Tomograms Summary → Total Tomograms → click **Go to Tomograms**.
3. Before: URL becomes `...?metadata=run&tab=metadata&table-tab=Tomograms`; reload reopens the drawer. After: URL is `...?table-tab=Tomograms`; reload keeps it closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
