### PR TITLE
fix: detect submitted alignments by per-section params, not method type

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-f7878c6
+        tag: sha-3eda32d
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-3eda32d
+        tag: sha-82ca49e
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/graphql/fragments/getDataContentsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/fragments/getDataContentsV2.server.ts
@@ -12,7 +12,7 @@ export const GET_DATA_CONTENTS_FRAGMENT = gql(`
         count
       }
     }
-    alignmentsAggregate(where: {alignmentMethod: {_is_null: false}}) {
+    alignmentsAggregate(where: {perSectionAlignmentsAggregate: {count: {predicate: {_gt: 0}}}}) {
       aggregate {
         count
       }

--- a/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getRunByIdV2.server.ts
@@ -230,9 +230,9 @@ const GET_RUN_BY_ID_QUERY_V2 = gql(`
     }
 
     # Header
-    # Filter by non-null alignment method since it can be null
+    # Filter to real alignments (those with per-section parameters), since default/identity alignments have none
     alignments(where: {
-      alignmentMethod: { _is_null: false, },
+      perSectionAlignmentsAggregate: { count: { predicate: { _gt: 0 } } },
       runId: { _eq: $id }
     }) {
       id


### PR DESCRIPTION
## Problem
The Dataset Contents summary shows "Alignment: Not Submitted" for datasets whose alignments have `method_type: undefined` (which the db-import maps to a null `alignmentMethod`), even when real per-section alignment data exists. This affects all simulated / undefined-method datasets (e.g. 10439, 10441, and the CryoETSim datasets 10490-10492).

## Fix
Count an alignment as submitted when it has per-section alignment parameters (`perSectionAlignmentsAggregate.count > 0`) rather than when `alignmentMethod` is non-null. Auto-generated default/identity placeholder alignments have zero per-section params, so they still correctly read as "Not Submitted", while real alignments (any method, including `undefined`) now show as "Available".

Verified against the staging API: the filter returns all real alignments and excludes zero-parameter placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
