### PR TITLE
feat: Show number of Annotations on the front page.

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     frontend:
       image:
-        tag: sha-f7878c6
+        tag: sha-1b8e6fa
       replicaCount: 1
       env:
         - name: API_URL_V2

--- a/frontend/packages/data-portal/app/components/Index/IndexHeader.tsx
+++ b/frontend/packages/data-portal/app/components/Index/IndexHeader.tsx
@@ -70,6 +70,11 @@ export function IndexHeader() {
               title={t('tomograms')}
               count={data.tomogramsAggregate.aggregate?.[0]?.count ?? 0}
             />
+            {DIVIDER}
+            <MetricField
+              title={t('annotations')}
+              count={data.annotationsAggregate.aggregate?.[0]?.count ?? 0}
+            />
           </div>
           <Link to="/browse-data/datasets">
             <Button

--- a/frontend/packages/data-portal/app/routes/_index.tsx
+++ b/frontend/packages/data-portal/app/routes/_index.tsx
@@ -22,6 +22,11 @@ const LANDING_PAGE_DATA_QUERY = gql(`
         count
       }
     }
+    annotationsAggregate {
+      aggregate {
+        count
+      }
+    }
   }
 `)
 


### PR DESCRIPTION
Adds a query for `annotationAggregate` to the index page and uses it to display the total number of Annotations on the portal's front page. 