### PR TITLE
feat: better surface tomogram processing/reconstruction software

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/DepositionTomogramTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DepositionTomogramTable.tsx
@@ -10,6 +10,7 @@ import { PageTable } from 'app/components/Table'
 import { TableClassNames } from 'app/components/Table/types'
 import { usePostProcessingColumn } from 'app/components/TomogramsTable/usePostProcessingColumn'
 import { useReconstructionMethodColumn } from 'app/components/TomogramsTable/useReconstructionMethodColumn'
+import { useSoftwareColumn } from 'app/components/TomogramsTable/useSoftwareColumn'
 import { useTomogramActionsColumn } from 'app/components/TomogramsTable/useTomogramActionsColumn'
 import { useTomogramKeyPhotoColumn } from 'app/components/TomogramsTable/useTomogramKeyPhotoColumn'
 import { useTomogramNameColumn } from 'app/components/TomogramsTable/useTomogramNameColumn'
@@ -86,6 +87,11 @@ export function DepositionTomogramTable({
     isLoading,
   })
 
+  const softwareColumn = useSoftwareColumn({
+    width: DepositionTomogramTableWidths.software,
+    isLoading,
+  })
+
   const depositedInColumn = useDepositedInColumn<DepositionTomogramTableData>({
     width: DepositionTomogramTableWidths.depositedIn,
     isLoading,
@@ -117,6 +123,7 @@ export function DepositionTomogramTable({
         voxelSpacingColumn,
         reconstructionMethodColumn,
         postProcessingColumn,
+        softwareColumn,
         depositedInColumn,
         tomogramActionsColumn,
       ] as ColumnDef<DepositionTomogramTableData>[],
@@ -125,6 +132,7 @@ export function DepositionTomogramTable({
       keyPhotoColumn,
       postProcessingColumn,
       reconstructionMethodColumn,
+      softwareColumn,
       tomogramActionsColumn,
       tomogramNameColumn,
       voxelSpacingColumn,

--- a/frontend/packages/data-portal/app/components/Deposition/MethodSummary/MethodSummaryTomogramsTable.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/MethodSummary/MethodSummaryTomogramsTable.tsx
@@ -3,6 +3,7 @@
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table'
 import { useMemo } from 'react'
 
+import { SoftwareCell } from 'app/components/Deposition/SoftwareCell'
 import { CellHeader, TableCell } from 'app/components/Table'
 import { TomogramMethodTableWidths } from 'app/constants/table'
 import {
@@ -87,6 +88,22 @@ export function MethodSummaryTomogramsTable() {
           <TableCell width={TomogramMethodTableWidths.ctfCorrected}>
             {t(row.original.ctfCorrected ? 'true' : 'false')}
           </TableCell>
+        ),
+      }),
+
+      columnHelper.accessor('reconstructionSoftware', {
+        header: () => (
+          <CellHeader width={TomogramMethodTableWidths.software}>
+            {t('software')}
+          </CellHeader>
+        ),
+
+        cell: ({ row }) => (
+          <SoftwareCell
+            reconstructionSoftware={row.original.reconstructionSoftware}
+            processingSoftware={row.original.processingSoftware}
+            width={TomogramMethodTableWidths.software}
+          />
         ),
       }),
     ] as ColumnDef<TomogramMethodMetadata>[]

--- a/frontend/packages/data-portal/app/components/Deposition/SoftwareCell.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/SoftwareCell.tsx
@@ -1,0 +1,62 @@
+import Skeleton from '@mui/material/Skeleton'
+
+import { TableCell } from 'app/components/Table/TableCell'
+import { type TableColumnWidth } from 'app/constants/table'
+import { useI18n } from 'app/hooks/useI18n'
+
+interface SoftwareCellProps {
+  reconstructionSoftware?: string | null
+  processingSoftware?: string | null
+  width: TableColumnWidth
+  isLoading?: boolean
+}
+
+function SoftwareRow({
+  label,
+  value,
+}: {
+  label: string
+  value?: string | null
+}) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-light-sds-color-semantic-base-text-secondary text-sds-body-xxs-400-wide leading-sds-body-xxs">
+        {label}
+      </span>
+      <span className="break-words">{value || '--'}</span>
+    </div>
+  )
+}
+
+export function SoftwareCell({
+  reconstructionSoftware,
+  processingSoftware,
+  width,
+  isLoading,
+}: SoftwareCellProps) {
+  const { t } = useI18n()
+
+  return (
+    <TableCell
+      width={width}
+      renderLoadingSkeleton={() => (
+        <div className="flex flex-col gap-sds-xs">
+          <Skeleton className="w-[120px]" variant="text" />
+          <Skeleton className="w-[120px]" variant="text" />
+        </div>
+      )}
+      showLoadingSkeleton={isLoading}
+    >
+      <div className="flex flex-col gap-sds-xs">
+        <SoftwareRow
+          label={t('reconstructionSoftware')}
+          value={reconstructionSoftware}
+        />
+        <SoftwareRow
+          label={t('processingSoftware')}
+          value={processingSoftware}
+        />
+      </div>
+    </TableCell>
+  )
+}

--- a/frontend/packages/data-portal/app/components/Run/RunTomogramsTable.tsx
+++ b/frontend/packages/data-portal/app/components/Run/RunTomogramsTable.tsx
@@ -8,6 +8,7 @@ import { I18n } from 'app/components/I18n'
 import { CellHeader, PageTable, TableCell } from 'app/components/Table'
 import { usePostProcessingColumn } from 'app/components/TomogramsTable/usePostProcessingColumn'
 import { useReconstructionMethodColumn } from 'app/components/TomogramsTable/useReconstructionMethodColumn'
+import { useSoftwareColumn } from 'app/components/TomogramsTable/useSoftwareColumn'
 import { useTomogramActionsColumn } from 'app/components/TomogramsTable/useTomogramActionsColumn'
 import { useTomogramKeyPhotoColumn } from 'app/components/TomogramsTable/useTomogramKeyPhotoColumn'
 import { useTomogramNameColumn } from 'app/components/TomogramsTable/useTomogramNameColumn'
@@ -62,6 +63,10 @@ export function RunTomogramsTable() {
 
   const postProcessingColumn = usePostProcessingColumn({
     width: TomogramTableWidths.postProcessing,
+  })
+
+  const softwareColumn = useSoftwareColumn({
+    width: TomogramTableWidths.software,
   })
 
   const tomogramActionsColumn = useTomogramActionsColumn({
@@ -141,6 +146,7 @@ export function RunTomogramsTable() {
       voxelSpacingColumn,
       reconstructionMethodColumn,
       postProcessingColumn,
+      softwareColumn,
       tomogramActionsColumn,
     ] as ColumnDef<TomogramV2>[] // https://github.com/TanStack/table/issues/4382
   }, [
@@ -149,6 +155,7 @@ export function RunTomogramsTable() {
     voxelSpacingColumn,
     reconstructionMethodColumn,
     postProcessingColumn,
+    softwareColumn,
     tomogramActionsColumn,
     t,
   ])

--- a/frontend/packages/data-portal/app/components/TomogramsTable/useSoftwareColumn.tsx
+++ b/frontend/packages/data-portal/app/components/TomogramsTable/useSoftwareColumn.tsx
@@ -1,0 +1,32 @@
+import { createColumnHelper } from '@tanstack/react-table'
+
+import type { Tomogram } from 'app/__generated_v2__/graphql'
+import { SoftwareCell } from 'app/components/Deposition/SoftwareCell'
+import { CellHeader } from 'app/components/Table/CellHeader'
+import { type TableColumnWidth } from 'app/constants/table'
+import { useI18n } from 'app/hooks/useI18n'
+
+const columnHelper = createColumnHelper<Tomogram>()
+
+export function useSoftwareColumn({
+  width,
+  isLoading,
+}: {
+  width: TableColumnWidth
+  isLoading?: boolean
+}) {
+  const { t } = useI18n()
+
+  return columnHelper.accessor('reconstructionSoftware', {
+    header: () => <CellHeader width={width}>{t('software')}</CellHeader>,
+
+    cell: ({ row: { original } }) => (
+      <SoftwareCell
+        reconstructionSoftware={original.reconstructionSoftware}
+        processingSoftware={original.processingSoftware}
+        width={width}
+        isLoading={isLoading}
+      />
+    ),
+  })
+}

--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -431,7 +431,23 @@ export function ViewerPage({
                       disabled={unsupportedTomogramSwitch(tomogram)}
                       onClick={() => handleTomogramChanged(tomogram)}
                       title={getTomogramName(tomogram)}
-                      subtitle={createTomogramInfoString(tomogram)}
+                      subtitle={
+                        <>
+                          <span className="block">
+                            {createTomogramInfoString(tomogram)}
+                          </span>
+                          {tomogram.reconstructionSoftware && (
+                            <span className="block">
+                              Rec: {tomogram.reconstructionSoftware}
+                            </span>
+                          )}
+                          {tomogram.processingSoftware && (
+                            <span className="block">
+                              Proc: {tomogram.processingSoftware}
+                            </span>
+                          )}
+                        </>
+                      }
                     />
                   )
                 })}

--- a/frontend/packages/data-portal/app/constants/table.ts
+++ b/frontend/packages/data-portal/app/constants/table.ts
@@ -40,6 +40,7 @@ export const TomogramTableWidths = {
   voxelSpacing: { max: 200 },
   reconstructionMethod: { max: 200 },
   postProcessing: { max: 200 },
+  software: { min: 200, max: 280 },
   actions: { width: 164 },
 }
 
@@ -83,6 +84,7 @@ export const TomogramMethodTableWidths = {
   reconstructionMethod: { width: 138 },
   postProcessing: { width: 96 },
   ctfCorrected: { width: 89 },
+  software: { width: 200 },
 }
 
 export const AcquisitionMethodTableWidths = {
@@ -113,6 +115,7 @@ export const DepositionTomogramTableWidths = {
   photo: PHOTO_COLUMN_WIDTH,
   name: { width: 200 },
   voxelSpacing: { width: 160 },
+  software: { width: 200 },
   reconstructionMethod: { width: 142 },
   postProcessing: { width: 120 },
   depositedIn: { width: 230 },

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -63,7 +63,9 @@ const GET_DEPOSITION_BASE_DATA = gql(`
           groupBy {
             voxelSpacing
             reconstructionMethod
+            reconstructionSoftware
             processing
+            processingSoftware
             ctfCorrected
           }
         }

--- a/frontend/packages/data-portal/app/graphql/getDepositionTomogramsV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionTomogramsV2.server.ts
@@ -40,7 +40,9 @@ const GET_DEPOSITION_TOMOGRAMS = gql(`
       name
       neuroglancerConfig
       processing
+      processingSoftware
       reconstructionMethod
+      reconstructionSoftware
       sizeX
       sizeY
       sizeZ

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -29,7 +29,9 @@ export interface TomogramMethodMetadata {
   count: number
   voxelSpacing: string
   reconstructionMethod: string
+  reconstructionSoftware: string
   processing: string
+  processingSoftware: string
   ctfCorrected: boolean
 }
 
@@ -162,7 +164,10 @@ export function useDepositionById() {
         count: aggregate.count ?? 0,
         voxelSpacing: aggregate.groupBy?.voxelSpacing?.toString() ?? '--',
         reconstructionMethod: aggregate.groupBy?.reconstructionMethod ?? '--',
+        reconstructionSoftware:
+          aggregate.groupBy?.reconstructionSoftware ?? '--',
         processing: aggregate.groupBy?.processing ?? '--',
+        processingSoftware: aggregate.groupBy?.processingSoftware ?? '--',
         ctfCorrected: aggregate.groupBy?.ctfCorrected ?? false,
       }))
       .sort((a, b) => b.count - a.count)

--- a/frontend/packages/data-portal/public/locales/en/translation.json
+++ b/frontend/packages/data-portal/public/locales/en/translation.json
@@ -583,6 +583,7 @@
   "snapAction": "Snap to nearest axis",
   "snapActionSuccess": "Snapped to nearest axis",
   "somethingWentWrong": "Something went wrong",
+  "software": "Software",
   "sourceCode": "Source Code",
   "species": "Species",
   "sphericalAberrationConstant": "Spherical Aberration Constant",


### PR DESCRIPTION
## Summary

Better surfaces tomogram **reconstruction software** and **processing software**, which today are only visible in the metadata info panel. This disambiguates tomograms that share a reconstruction method + post-processing but differ only by software (e.g. three "WBP Denoised" tomograms distinguished only by `processing_software`).

### Changes

**Run & Deposition tomogram tables** — new **Software** column with two rows (grey label / black value): Reconstruction Software and Processing Software. Column order is now:

`Reconstruction Method → Post Processing → Software → View Tomogram`

**Deposition methods-summary table** — new **Software** column on the far right. The aggregate `groupBy` now includes `reconstructionSoftware` / `processingSoftware` so each software combination is its own row.

**Neuroglancer viewer** — instead of modifying the tomogram name, each tomogram dropdown option now shows grey `Rec:` and `Proc:` subtitle lines with the reconstruction/processing software.

### Implementation notes

- New `SoftwareCell` + `useSoftwareColumn` (renders software verbatim — software names carry meaningful casing/versions, so no `startCase`/capitalization; `--` when null, and ~30% of tomograms have null `processing_software`).
- Added `reconstructionSoftware` / `processingSoftware` to the deposition tomograms and deposition-by-id GraphQL queries (the run query already fetched them).
- Added `software` i18n key + table widths.

### Testing

- `pnpm test` — 330 passed, 1 skipped ✓
- `pnpm data-portal type-check` ✓ (pre-existing unrelated `ViewerPage` neuroglancer `flushStateToUrl` error only)
- `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)