### PR TITLE
perf(deposition): fix slow deposition page load for large depositions

### DIFF
--- a/frontend/packages/data-portal/app/components/Deposition/DepositionFilters.tsx
+++ b/frontend/packages/data-portal/app/components/Deposition/DepositionFilters.tsx
@@ -6,14 +6,13 @@ import { useDepositionById } from 'app/hooks/useDepositionById'
 import { useDepositionGroupedData } from 'app/hooks/useDepositionGroupedData'
 import { useI18n } from 'app/hooks/useI18n'
 import { cns } from 'app/utils/cns'
-import { getDataContents } from 'app/utils/deposition'
 import { isDefined } from 'app/utils/nullish'
 
 import { DatasetNameOrIdFilter } from '../Filters/DatasetNameOrIdFilter'
 import { DepositionTabs } from './DepositionTabs'
 
 function DepositionFiltersContent() {
-  const { allRuns } = useDepositionById()
+  const { dataContents } = useDepositionById()
 
   // Use the new hook to get datasets
   const { datasets } = useDepositionGroupedData({
@@ -28,25 +27,24 @@ function DepositionFiltersContent() {
       ].sort(),
     [datasets],
   )
-  const dataContents = getDataContents(allRuns ?? [])
   const dataContentItems = useMemo(
     () =>
       [
         {
           label: 'tiltSeries',
-          isAvailable: dataContents.tiltSeriesAvailable,
+          isAvailable: dataContents?.tiltSeriesAvailable ?? false,
         },
         {
           label: 'frames',
-          isAvailable: dataContents.framesAvailable,
+          isAvailable: dataContents?.framesAvailable ?? false,
         },
         {
           label: 'ctf',
-          isAvailable: dataContents.ctfAvailable,
+          isAvailable: dataContents?.ctfAvailable ?? false,
         },
         {
           label: 'alignment',
-          isAvailable: dataContents.alignmentAvailable,
+          isAvailable: dataContents?.alignmentAvailable ?? false,
         },
       ] as const,
     [dataContents],

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -5,11 +5,9 @@ import {
 } from '@apollo/client'
 
 import { gql } from 'app/__generated_v2__'
-import {
-  GetDepositionBaseDataV2Query,
-  GetDepositionExpandedDataV2Query,
-} from 'app/__generated_v2__/graphql'
+import { GetDepositionBaseDataV2Query } from 'app/__generated_v2__/graphql'
 import { getFilterState } from 'app/hooks/useFilter'
+import { DepositionDataContents } from 'app/types/deposition-queries'
 
 import {
   getDepositionAnnotationsFilter,
@@ -194,15 +192,48 @@ const GET_DEPOSITION_BASE_DATA = gql(`
   }
 `)
 
-// Query for allRuns data used in DepositionFilters
-const GET_DEPOSITION_EXPANDED_DATA = gql(`
-  query GetDepositionExpandedDataV2($id: Int!) {
-    allRuns: runs(where: {
-      annotations: {
-        depositionId: { _eq: $id }
+// DepositionFilters only needs to know whether each data type exists anywhere in
+// the deposition's runs. Fetching per-run aggregates over every run was O(runs) and
+// pathologically slow for large depositions (tens of thousands of runs). These
+// existence checks are cheap, but the API errors when several of these deep
+// run-relation aggregates are combined into one query, so each is issued separately
+// (in parallel) below.
+const GET_DEPOSITION_TILT_SERIES_AVAILABLE = gql(`
+  query GetDepositionTiltSeriesAvailableV2($id: Int!) {
+    tiltseriesAggregate(where: { run: { annotations: { depositionId: { _eq: $id } } } }) {
+      aggregate {
+        count
       }
-    }) {
-      ...DataContents
+    }
+  }
+`)
+
+const GET_DEPOSITION_FRAMES_AVAILABLE = gql(`
+  query GetDepositionFramesAvailableV2($id: Int!) {
+    framesAggregate(where: { run: { annotations: { depositionId: { _eq: $id } } }, httpsFramePath: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`)
+
+const GET_DEPOSITION_CTF_AVAILABLE = gql(`
+  query GetDepositionCtfAvailableV2($id: Int!) {
+    perSectionParametersAggregate(where: { run: { annotations: { depositionId: { _eq: $id } } }, majorDefocus: { _is_null: false } }) {
+      aggregate {
+        count
+      }
+    }
+  }
+`)
+
+const GET_DEPOSITION_ALIGNMENTS_AVAILABLE = gql(`
+  query GetDepositionAlignmentsAvailableV2($id: Int!) {
+    alignmentsAggregate(where: { run: { annotations: { depositionId: { _eq: $id } } }, alignmentMethod: { _is_null: false } }) {
+      aggregate {
+        count
+      }
     }
   }
 `)
@@ -245,18 +276,54 @@ export async function getDepositionBaseData({
   })
 }
 
-// Data function for allRuns used in DepositionFilters
+function hasAny(
+  aggregate: ({ count?: number | null } | null)[] | null | undefined,
+): boolean {
+  return (
+    (aggregate?.reduce((total, node) => total + (node?.count ?? 0), 0) ?? 0) > 0
+  )
+}
+
+// Data contents availability used in DepositionFilters. Each existence check is a
+// separate query (see note above) run in parallel.
 export async function getDepositionExpandedData({
   client,
   id,
 }: {
   client: ApolloClient<NormalizedCacheObject>
   id: number
-}): Promise<ApolloQueryResult<GetDepositionExpandedDataV2Query>> {
-  return client.query({
-    query: GET_DEPOSITION_EXPANDED_DATA,
-    variables: {
-      id,
+}): Promise<{ data: { dataContents: DepositionDataContents } }> {
+  const [tiltSeries, frames, ctf, alignments] = await Promise.all([
+    client.query({
+      query: GET_DEPOSITION_TILT_SERIES_AVAILABLE,
+      variables: { id },
+    }),
+    client.query({
+      query: GET_DEPOSITION_FRAMES_AVAILABLE,
+      variables: { id },
+    }),
+    client.query({
+      query: GET_DEPOSITION_CTF_AVAILABLE,
+      variables: { id },
+    }),
+    client.query({
+      query: GET_DEPOSITION_ALIGNMENTS_AVAILABLE,
+      variables: { id },
+    }),
+  ])
+
+  return {
+    data: {
+      dataContents: {
+        tiltSeriesAvailable: hasAny(
+          tiltSeries.data.tiltseriesAggregate.aggregate,
+        ),
+        framesAvailable: hasAny(frames.data.framesAggregate.aggregate),
+        ctfAvailable: hasAny(ctf.data.perSectionParametersAggregate.aggregate),
+        alignmentAvailable: hasAny(
+          alignments.data.alignmentsAggregate.aggregate,
+        ),
+      },
     },
-  })
+  }
 }

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -99,8 +99,7 @@ const GET_DEPOSITION_BASE_DATA = gql(`
       }
     }
 
-    # Distinct (method, software, methodType) tuples via aggregate groupBy, so per-method
-    # metadata is complete regardless of pagination (much cheaper than fetching annotation rows).
+    # Distinct (method, software, methodType) tuples for per-method metadata.
     annotationMethodMetadata: annotationsAggregate(where: { depositionId: { _eq: $id } }) {
       aggregate {
         count
@@ -195,12 +194,8 @@ const GET_DEPOSITION_BASE_DATA = gql(`
   }
 `)
 
-// DepositionFilters only needs to know whether each data type exists anywhere in
-// the deposition's runs. Fetching per-run aggregates over every run was O(runs) and
-// pathologically slow for large depositions (tens of thousands of runs). These
-// existence checks are cheap, but the API errors when several of these deep
-// run-relation aggregates are combined into one query, so each is issued separately
-// (in parallel) below.
+// Separate queries: the API errors when these run-relation aggregates are combined
+// into one request. Run in parallel by getDepositionExpandedData.
 const GET_DEPOSITION_TILT_SERIES_AVAILABLE = gql(`
   query GetDepositionTiltSeriesAvailableV2($id: Int!) {
     tiltseriesAggregate(where: { run: { annotations: { depositionId: { _eq: $id } } } }) {
@@ -287,8 +282,6 @@ function hasAny(
   )
 }
 
-// Data contents availability used in DepositionFilters. Each existence check is a
-// separate query (see note above) run in parallel.
 export async function getDepositionExpandedData({
   client,
   id,

--- a/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
+++ b/frontend/packages/data-portal/app/graphql/getDepositionByIdV2.server.ts
@@ -45,16 +45,6 @@ const GET_DEPOSITION_BASE_DATA = gql(`
           }
         }
       }
-      annotations(where: {depositionId: {_eq: $id}}) {
-        edges {
-          node {
-            annotationMethod
-            annotationSoftware
-            methodType
-          }
-        }
-      }
-
       tomogramMethodCounts: tomogramsAggregate(where: { depositionId: { _eq: $id } }) {
         aggregate {
           count
@@ -105,6 +95,19 @@ const GET_DEPOSITION_BASE_DATA = gql(`
           annotation {
             annotationMethod
           }
+        }
+      }
+    }
+
+    # Distinct (method, software, methodType) tuples via aggregate groupBy, so per-method
+    # metadata is complete regardless of pagination (much cheaper than fetching annotation rows).
+    annotationMethodMetadata: annotationsAggregate(where: { depositionId: { _eq: $id } }) {
+      aggregate {
+        count
+        groupBy {
+          annotationMethod
+          annotationSoftware
+          methodType
         }
       }
     }

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -66,8 +66,8 @@ export function useDepositionById() {
       Omit<AnnotationMethodMetadata, 'annotationMethod'>
     >()
 
-    // Authoritative method list + SHAPE counts (annotations.edges is paginated). Counts
-    // use annotation shapes so they match "# annotations" shown elsewhere and add up.
+    // Authoritative method list + SHAPE counts (counts use annotation shapes so they
+    // match "# annotations" shown elsewhere and add up).
     for (const aggregate of v2.annotationMethodCounts?.aggregate ?? []) {
       const annotationMethod = aggregate.groupBy?.annotation?.annotationMethod
       if (annotationMethod == null) {
@@ -81,8 +81,7 @@ export function useDepositionById() {
       })
     }
 
-    // Enrich software/methodType per method from distinct (method, software, methodType)
-    // tuples (aggregate groupBy — complete and cheap, unlike paginated annotation rows).
+    // Enrich software/methodType per method.
     for (const { groupBy } of v2.annotationMethodMetadata?.aggregate ?? []) {
       const annotationMethod = groupBy?.annotationMethod
       if (groupBy == null || annotationMethod == null) continue

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -7,10 +7,10 @@ import {
   Annotation_Method_Type_Enum,
   type GetDepositionAnnotationsQuery,
   GetDepositionBaseDataV2Query,
-  GetDepositionExpandedDataV2Query,
   type GetDepositionTomogramsQuery,
 } from 'app/__generated_v2__/graphql'
 import { METHOD_TYPE_ORDER } from 'app/constants/methodTypes'
+import { DepositionDataContents } from 'app/types/deposition-queries'
 import { isDefined } from 'app/utils/nullish'
 
 export interface AnnotationMethodMetadata {
@@ -55,7 +55,7 @@ export interface ExperimentalConditionsMethodMetadata {
 export function useDepositionById() {
   const { v2, expandedData, annotations, tomograms } = useTypedLoaderData<{
     v2: GetDepositionBaseDataV2Query
-    expandedData?: GetDepositionExpandedDataV2Query
+    expandedData?: { dataContents: DepositionDataContents }
     annotations?: GetDepositionAnnotationsQuery
     tomograms?: GetDepositionTomogramsQuery
   }>()
@@ -248,7 +248,7 @@ export function useDepositionById() {
     objectShapeTypes,
     annotations,
     tomograms,
-    allRuns: expandedData?.allRuns,
+    dataContents: expandedData?.dataContents,
     deposition: v2.depositions[0],
 
     annotationsCount:

--- a/frontend/packages/data-portal/app/hooks/useDepositionById.ts
+++ b/frontend/packages/data-portal/app/hooks/useDepositionById.ts
@@ -81,16 +81,16 @@ export function useDepositionById() {
       })
     }
 
-    // Enrich from annotations (may be a subset of rows); metadata comes from edges when present
-    for (const { node } of v2.depositions[0]?.annotations?.edges ?? []) {
-      if (!node) continue
-      const { annotationMethod } = node
-      if (annotationMethod == null) continue
+    // Enrich software/methodType per method from distinct (method, software, methodType)
+    // tuples (aggregate groupBy — complete and cheap, unlike paginated annotation rows).
+    for (const { groupBy } of v2.annotationMethodMetadata?.aggregate ?? []) {
+      const annotationMethod = groupBy?.annotationMethod
+      if (groupBy == null || annotationMethod == null) continue
 
       if (!annotationMethodToMetadata.has(annotationMethod)) {
         annotationMethodToMetadata.set(annotationMethod, {
-          annotationSoftware: node.annotationSoftware ?? undefined,
-          methodType: node.methodType ?? undefined,
+          annotationSoftware: groupBy.annotationSoftware ?? undefined,
+          methodType: groupBy.methodType ?? undefined,
           count: 0,
           methodLinks: [],
         })
@@ -99,12 +99,12 @@ export function useDepositionById() {
       const meta = annotationMethodToMetadata.get(annotationMethod)!
       if (
         meta.annotationSoftware === undefined &&
-        node.annotationSoftware != null
+        groupBy.annotationSoftware != null
       ) {
-        meta.annotationSoftware = node.annotationSoftware
+        meta.annotationSoftware = groupBy.annotationSoftware
       }
-      if (meta.methodType === undefined && node.methodType != null) {
-        meta.methodType = node.methodType
+      if (meta.methodType === undefined && groupBy.methodType != null) {
+        meta.methodType = groupBy.methodType
       }
     }
 
@@ -151,7 +151,11 @@ export function useDepositionById() {
             annotationMethodB.methodType ?? Annotation_Method_Type_Enum.Manual,
           ),
       )
-  }, [v2.depositions, v2.annotationMethodCounts, v2.annotationMethodLinks])
+  }, [
+    v2.annotationMethodCounts,
+    v2.annotationMethodMetadata,
+    v2.annotationMethodLinks,
+  ])
 
   const tomogramMethods: TomogramMethodMetadata[] = useMemo(() => {
     const tomogramMethodsData =

--- a/frontend/packages/data-portal/app/types/deposition-queries.ts
+++ b/frontend/packages/data-portal/app/types/deposition-queries.ts
@@ -63,6 +63,15 @@ export interface ItemsByOrganismResponse {
   tomograms?: GetDepositionTomogramsQuery['tomograms']
 }
 
+// Whether each data type exists anywhere in a deposition's runs, shown in the
+// DepositionFilters "Data Contents" panel.
+export interface DepositionDataContents {
+  tiltSeriesAvailable: boolean
+  framesAvailable: boolean
+  ctfAvailable: boolean
+  alignmentAvailable: boolean
+}
+
 // Generic types for unified hooks
 export enum DataContentsType {
   Annotations = 'annotations',

--- a/frontend/packages/data-portal/app/utils/deposition/dataFetchers.ts
+++ b/frontend/packages/data-portal/app/utils/deposition/dataFetchers.ts
@@ -66,8 +66,6 @@ export async function fetchDepositionData({
   params,
   url,
 }: FetchDepositionDataParams): Promise<DepositionData> {
-  // Fetch all three in parallel — base data no longer blocks the others (the 404
-  // check just moves after the await).
   const [{ data: responseV2 }, { data: expandedData }, { data }] =
     await Promise.all([
       getDepositionBaseData({

--- a/frontend/packages/data-portal/app/utils/deposition/dataFetchers.ts
+++ b/frontend/packages/data-portal/app/utils/deposition/dataFetchers.ts
@@ -25,36 +25,6 @@ export interface DepositionData {
 }
 
 /**
- * Validates that a deposition exists by fetching base data
- * @param client - Apollo client instance
- * @param id - Deposition ID to validate
- * @param params - URL search parameters for filtering
- * @throws Response with 404 status if deposition not found
- * @returns Base deposition data
- */
-async function validateDepositionExists(
-  client: ApolloClient<NormalizedCacheObject>,
-  id: number,
-  params: URLSearchParams,
-) {
-  const { data: responseV2 } = await getDepositionBaseData({
-    client,
-    id,
-    params,
-  })
-
-  if (responseV2.depositions.length === 0) {
-    // eslint-disable-next-line @typescript-eslint/no-throw-literal
-    throw new Response(null, {
-      status: 404,
-      statusText: `Deposition with ID ${id} not found`,
-    })
-  }
-
-  return responseV2
-}
-
-/**
  * Fetches conditional data based on tab selection
  * @param client - Apollo client instance
  * @param params - Loader parameters
@@ -96,18 +66,26 @@ export async function fetchDepositionData({
   params,
   url,
 }: FetchDepositionDataParams): Promise<DepositionData> {
-  // First validate existence
-  const responseV2 = await validateDepositionExists(
-    client,
-    params.id,
-    url.searchParams,
-  )
+  // Fetch all three in parallel — base data no longer blocks the others (the 404
+  // check just moves after the await).
+  const [{ data: responseV2 }, { data: expandedData }, { data }] =
+    await Promise.all([
+      getDepositionBaseData({
+        client,
+        id: params.id,
+        params: url.searchParams,
+      }),
+      getDepositionExpandedData({ client, id: params.id }),
+      fetchConditionalData(client, params, url),
+    ])
 
-  // Then fetch remaining data in parallel
-  const [{ data: expandedData }, { data }] = await Promise.all([
-    getDepositionExpandedData({ client, id: params.id }),
-    fetchConditionalData(client, params, url),
-  ])
+  if (responseV2.depositions.length === 0) {
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal
+    throw new Response(null, {
+      status: 404,
+      statusText: `Deposition with ID ${params.id} not found`,
+    })
+  }
 
   return {
     expandedData,


### PR DESCRIPTION
## Problem

Loading a large deposition page (e.g. deposition 10318, 27k tomograms) took **20s+**. Measured end-to-end SSR load: **~20s -> ~3.3s**.

## Three fixes (all in the deposition loader / `getDepositionByIdV2`)

### 1. Data-contents availability: O(runs) -> existence checks
The expanded query fetched **every run** in the deposition, each with 6 per-run aggregate counts, only to derive 4 booleans (tiltseries/frames/ctf/alignment available) for the filter panel. For dep 10318 that's **12,606 runs x 6 aggregates ~= 30s**.

Replaced with 4 deposition-scoped existence aggregates, run in parallel: **~30s -> ~1.4s**. (They must be separate queries — the API errors when several of these deep `run.annotations.depositionId` aggregates are combined into one request.) The `DataContents` fragment / `getDataContents` util are kept for the Dataset page, which uses them over a bounded run count.

### 2. Parallelize the loader
The base-data query ran **serially before** the expanded + conditional fetches (only to do a 404 existence check). Now all three run in `Promise.all`; the 404 check moves after the await. Removes a full query from the critical-path waterfall.

### 3. Drop the slow `annotations { edges }` in the base query
The base query fetched a paginated page of annotation rows (~3s for 100 rows) solely to enrich each method with its `annotationSoftware` / `methodType`. Replaced with an `annotationsAggregate` groupBy over distinct `(annotationMethod, annotationSoftware, methodType)` tuples: **~3s -> ~0.25s**, and complete rather than capped at 100 rows.

## Result

| Stage | End-to-end SSR load (dep 10318) |
|---|---|
| Before | ~20s |
| After fix #1 | ~8.3s |
| After #2 + #3 | **~3.3s** |

## Changes
- `getDepositionByIdV2.server.ts` — existence-check queries replace `allRuns`; `annotationMethodMetadata` aggregate replaces the annotations-edges selection.
- `utils/deposition/dataFetchers.ts` — parallelize base + expanded + conditional.
- `useDepositionById.ts` — enrich methods from the aggregate; expose `dataContents` instead of `allRuns`.
- `DepositionFilters.tsx` — consume `dataContents` directly.
- `types/deposition-queries.ts` — new `DepositionDataContents` interface.

## Testing
- `pnpm test` — 330 passed, 1 skipped
- `pnpm data-portal type-check` (only the pre-existing unrelated `ViewerPage` neuroglancer error)
- `pnpm lint`
- Verified locally against staging: page renders 200 with correct annotation methods/software (membrain-seg 0.0.1, SABER 0.9.0) and data-contents availability; load ~3.3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
