### PR TITLE
feat(infra): add Envoy Gateway route for cryoet-frontend (coexist phase, CCIE-7205)

### DIFF
--- a/.infra/common.yaml
+++ b/.infra/common.yaml
@@ -24,3 +24,8 @@ stack:
         paths:
           - path: /
             pathType: Prefix
+      gateway:
+        enabled: true
+        paths:
+          - path: /
+            pathType: Prefix

--- a/.infra/prod/Chart.yaml
+++ b/.infra/prod/Chart.yaml
@@ -4,5 +4,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: stack
-    version: 2.47.0
+    version: 2.54.0
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/prod/values.yaml
+++ b/.infra/prod/values.yaml
@@ -3,6 +3,10 @@ stack:
     frontend:
       image:
         tag: sha-ad07559
+      ingress:
+        enabled: true
+      gateway:
+        dnsOwner: ingress
       replicaCount: 2
       env:
         - name: API_URL_V2

--- a/.infra/rdev/Chart.yaml
+++ b/.infra/rdev/Chart.yaml
@@ -4,5 +4,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: stack
-    version: 2.49.1
+    version: 2.54.0
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/staging/Chart.yaml
+++ b/.infra/staging/Chart.yaml
@@ -4,5 +4,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: stack
-    version: 2.49.1
+    version: 2.54.0
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/staging/values.yaml
+++ b/.infra/staging/values.yaml
@@ -3,6 +3,10 @@ stack:
     frontend:
       image:
         tag: sha-ad07559
+      ingress:
+        enabled: true
+      gateway:
+        dnsOwner: ingress
       replicaCount: 1
       env:
         - name: API_URL_V2


### PR DESCRIPTION
## Summary

Adds an Envoy Gateway HTTPRoute for `frontend` alongside the existing nginx Ingress, and moves the chart pin to 2.54.0 (prod was on 2.47.0). Nothing changes for users on merge — prod and staging keep their Ingress and their DNS. A follow-up one-liner flips `gateway.dnsOwner`, and a third removes `ingress.*`.

Staging holds a coexist window rather than swapping outright, since it takes 40k requests a week. Only rdev swaps in one step. Prod is 307k/week and I'd like an owner watching when we flip.

## Review focus

- `cryoetdataportal.czscience.com` looks like a CloudFront distribution with this stack's host as origin, so the eventual flip moves the **public portal's origin**, not an internal name. Please confirm the origin is `genuine-sloth.prod-cryoet.prod.czi.team` and that nothing pins the origin cert — the gateway serves the shared `*.prod-cryoet` wildcard rather than a per-host cert.
- The pin has to move: 2.47.0 predates the chart's gateway HSTS default, so cutting over on it would silently drop `Strict-Transport-Security` from a public site.
- The 60s timeout becomes total-transaction. Unlikely to matter for an SSR frontend behind a CDN, but if any route streams, tell me and I'll raise it before the flip.
- `ingress.enabled: true` in the prod and staging values is load-bearing — without it the chart auto-disables the Ingress and this stops being a coexist.

## Test plan

- Both HTTPRoutes `Accepted` with `ResolvedRefs`
- `curl --resolve <host>:443:<gateway-NLB-IP>` returns 200 while `dig` still shows the nginx NLB
- Chart bump is workload-neutral: Deployment, Service and PDB render byte-identical across 2.47.0 → 2.54.0
