### PR TITLE
feat(infra): cut cryoet-frontend prod over to the Envoy Gateway (CCIE-7205)

### DIFF
--- a/.infra/prod/values.yaml
+++ b/.infra/prod/values.yaml
@@ -6,7 +6,7 @@ stack:
       ingress:
         enabled: true
       gateway:
-        dnsOwner: ingress
+        dnsOwner: gateway
       replicaCount: 2
       env:
         - name: API_URL_V2


### PR DESCRIPTION
## Summary

Flips `gateway.dnsOwner` to `gateway` for prod, moving DNS for `genuine-sloth.prod-cryoet.prod.czi.team` to the gateway NLB. Follows the coexist PR #2120. The Ingress stays for stale-DNS clients; cleanup is a later PR.

## Review focus

- **This moves the public portal's CloudFront origin.** Distribution `E25QWUF3R3X7CD` has origin `genuine-sloth.prod-cryoet.prod.czi.team`, https-only, 30s read timeout. Origin is by hostname, so CloudFront follows the flip with no distribution change; the gateway covers the name under the `*.prod-cryoet.prod.czi.team` wildcard, which https-only requires.
- **No staging rehearsal was possible.** The staging stack (`famous-redfish`) tracks `release-please--branches--main--components--cryoet-data-portal-frontend`, which has no open PR, so it never picked up #2120 and still has no HTTPRoute. Prod was verified directly instead.
- Rollback is this line in reverse, effective about two minutes after the revert syncs.

## Test plan

- HTTPRoute `genuine-sloth-stack-frontend`: `Accepted=True`, `ResolvedRefs=True`, 2/2 backends.
- Direct at the gateway NLB: **HTTP 200**, `ssl_verify=0`, cert `CN=*.prod-cryoet.prod.czi.team`.
- `dig` still on the nginx NLB IP set — expected during coexist, and what this changes.
- After merge: `dig` moves to the gateway NLB IPs and the page still loads over public DNS.
