### PR TITLE
docs: document the lint, test and build scripts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,6 +45,21 @@ The npm script `dev` can be used for starting the data portal dev server:
 pnpm dev
 ```
 
+## Lint, Test and Build
+
+The same scripts exist at the workspace root and run recursively across every package:
+
+```sh
+# lint all packages (add :fix to apply fixable findings)
+pnpm lint
+
+# run all package test suites
+pnpm test
+
+# production build of all packages
+pnpm build
+```
+
 ## Docker Compose
 
 A docker compose file is provided for convenience in starting up and destroying frontend services during local development:


### PR DESCRIPTION
## Summary

`frontend/README.md` documented only `pnpm dev`, while the workspace also defines `lint`, `lint:fix`, `test` and `build` — each running recursively across packages via `pnpm -r`. Contributors had to read `package.json` to find them. Adds a short section next to the dev-server one.

## Why now

This is deliberately a small in-path change. The cryoet-frontend **staging** stack deploys from `release-please--branches--main--components--cryoet-data-portal-frontend`, which currently has no open PR, so it never picked up the Envoy coexist change merged in #2120 and still has no HTTPRoute. `argus-stack-staging-upsert.yaml` only upserts that stack from a PR on that exact branch, so staging cannot be rebuilt until release-please cuts a new release for the `frontend` package. Tracked in CCIE-7281.

Merging this should produce that release PR, which recreates the branch from current `main` and rebuilds the staging stack.

## Review focus

One thing to check: I typed this `docs`, which is the accurate type and is a configured changelog section. But every past frontend release contains at least one `feat` or `fix`, so I can't prove from history that a docs-only commit bumps the version — if release-please declines to cut a release, this needs retyping as `fix` (or pairing with a real one). Happy to adjust rather than guess.

## Test plan

Docs only. After merge, confirm a `frontend` release PR appears and the staging stack returns.