### PR TITLE
feat(infra): cut cryoet-frontend staging over to the Envoy Gateway (CCIE-7205)

### DIFF
--- a/.infra/staging/values.yaml
+++ b/.infra/staging/values.yaml
@@ -6,7 +6,7 @@ stack:
       ingress:
         enabled: true
       gateway:
-        dnsOwner: ingress
+        dnsOwner: gateway
       replicaCount: 1
       env:
         - name: API_URL_V2


### PR DESCRIPTION
## Summary

Flips `gateway.dnsOwner` to `gateway` for staging, moving DNS for `famous-redfish.staging-cryoet.staging.czi.team` from the nginx NLB to the gateway NLB. This is the last stack on `staging-cryoet` still served by nginx — apiv2 staging cut over earlier today.

## Review focus

- **Merging this does not deploy it.** The staging stack is upserted only by `argus-stack-staging-upsert.yaml`, which requires a PR whose head branch is `release-please--branches--main--components--cryoet-data-portal-frontend`. The currently open release PR (#2123) regenerated its branch from `main` before this change existed, so the flip reaches staging only when release-please next regenerates that branch — i.e. after another releasable `frontend/` commit. See CCIE-7281; this is the second time today the same mechanism has stranded a merged change.
- Rollback is this line in reverse, effective about two minutes after the revert syncs — subject to the same deployment caveat.

## Test plan

The coexist window is verified, now that the stack has actually received the route from #2120:

- HTTPRoute `famous-redfish-stack-frontend`: `Accepted=True`, `ResolvedRefs=True`, 2/2 backends ready.
- Addressed directly at the gateway NLB: **200**, `ssl_verify=0`.
- Over public DNS through nginx: **200**. Both paths serve.
- `dig` still resolves to the nginx NLB pair — expected during coexist, and what this PR changes.

After it deploys: confirm `dig` moves to the gateway NLB set and the page still loads. Note the staging frontend calls `graphql.cryoet.staging.si.czi.technology`, which is a separate CloudFront in front of apiv2 staging — I verified it still returns real data after apiv2 staging cut over, so this flip does not touch that dependency.