### PR TITLE
ci: upsert the staging stack from main, not only from the release branch

### DIFF
--- a/.github/workflows/argus-stack-staging-upsert.yaml
+++ b/.github/workflows/argus-stack-staging-upsert.yaml
@@ -6,20 +6,38 @@ on:
     paths:
       - '.infra/common.yaml'
       - '.infra/staging/values.yaml'
+  push:
+    branches: [ main ]
+    paths:
+      - '.infra/common.yaml'
+      - '.infra/staging/values.yaml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  run_if:
-    if: github.head_ref == 'release-please--branches--main--components--cryoet-data-portal-frontend'
+  should_run:
     runs-on: ARM64
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
     steps:
-      - run: echo "The head branch of this PR is the release please branch"
+      - id: decide
+        env:
+          RELEASE_BRANCH: release-please--branches--main--components--cryoet-data-portal-frontend
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.head_ref }}" = "$RELEASE_BRANCH" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
 
   staging_stack_upsert:
-    needs: run_if
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     runs-on: ARM64
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Draft, because this changes what "staging" tracks and that is your call, not mine.

Today `argus-stack-staging-upsert.yaml` upserts the staging stack only from a PR whose head branch is `release-please--branches--main--components--cryoet-data-portal-frontend`. That branch is deleted when a release merges and recreated only when the next release is cut, so the staging stack is pinned to an ephemeral ref. Between releases, anything merged to `main` never reaches staging.

This adds a `push: main` trigger with the same path filter, plus `workflow_dispatch` for manual recovery, and leaves the existing release-branch PR trigger in place.

## Why this is worth deciding now

It has stranded two changes in this repo in one day:

- The Envoy coexist change (#2120) merged, but the staging stack was tracking a release branch with no open PR, so it sat undeployed for a day and staging had no HTTPRoute.
- The staging cutover (#2124) is merged-or-merging against the same problem: the currently open release PR regenerated its branch from `main` before that change existed, so the flip cannot reach staging until another releasable `frontend/` commit appears.

The sibling repo hit the identical thing: cryoet-data-portal-backend#777 merged, staging never received it, and the stack went to `ComparisonError: unable to resolve 'release-please--branches--main--components--apiv2' to a commit SHA` once its branch was deleted. Recovering it required merging an unrelated doc fix purely to trigger a release. Tracked in CCIE-7281.

## Review focus

- **The semantic change:** staging would deploy `main`'s values as soon as they merge, rather than only at release-candidate time. Image tags still come from whatever is committed in `.infra/staging/values.yaml`, which the release PR bumps — so released images still reach staging the same way. What changes is that non-image `.infra` edits stop waiting for a release. If "staging only ever runs a release candidate" is deliberate, this is the wrong fix and I would rather add just `workflow_dispatch` and leave the pinning alone.
- The `should_run` gate replaces the old `if: github.head_ref == …` job, because `head_ref` is empty on `push` and would have blocked it. Same behaviour for the PR path.
- `postStackDetails: comment` is a no-op outside a PR context, per the action's own docs.

## Test plan

Nothing to run pre-merge. After merge, editing `.infra/staging/values.yaml` on `main` should upsert the staging stack directly, and `workflow_dispatch` should give a manual re-trigger when a stack needs rebuilding.

The same change is needed in cryoet-data-portal-backend if you want it — I have not raised that one pending your read on this.