### PR TITLE
feat(infra): remove the nginx Ingress from cryoet-frontend prod (CCIE-7205)

### DIFF
--- a/.infra/prod/values.yaml
+++ b/.infra/prod/values.yaml
@@ -3,10 +3,6 @@ stack:
     frontend:
       image:
         tag: sha-ad07559
-      ingress:
-        enabled: true
-      gateway:
-        dnsOwner: gateway
       replicaCount: 2
       env:
         - name: API_URL_V2


### PR DESCRIPTION
## Summary

The frontend counterpart to cryoet-data-portal-backend#785. Drops `ingress.enabled` and the `gateway.dnsOwner` knob from prod, so the nginx Ingress stops being rendered.

## Review focus

- **The `ingress.paths` block in `common.yaml` is deliberately left in place.** With `gateway.enabled: true` and no explicit `ingress.enabled: true`, the chart auto-disables the Ingress, so that block renders nothing — confirmed below. It is still shared with staging and rdev, so removing it belongs in a final sweep once those are done rather than here, where it would change other environments.
- **This is the point of no easy return.** Until now a stale-DNS client was still served by nginx; after this it fails. nginx is at ~1 log line per 10 minutes for this host against 34 on Envoy, so that population is small but not zero.
- **Rollback is no longer a one-line revert.** Reverting this alone restores the Ingress while DNS stays on the gateway; a real rollback needs the `ingress` block back *and* `gateway.dnsOwner: ingress` in the same change.
- Note #2116 is an open updatecli chart bump for frontend prod. It touches `.infra/prod/Chart.yaml`, not values, so it should not conflict — worth sequencing rather than merging both blind.

## Test plan

Rendered against the pinned chart with the injected hostname simulated:

- **0** Ingress objects, **exactly 1** HTTPRoute, hostname `genuine-sloth.prod-cryoet.prod.czi.team`, no render errors.

Live state, which is the gate:

- Ingress carries `external-dns…/exclude: true`, the HTTPRoute carries none — the gateway owns DNS.
- `dig` resolves to the gateway NLB IP set.
- `GET /` returns 200 direct, and the public portal through CloudFront returns 200 with the page rendering (`<title>CryoET Data Portal</title>`), including a deep route.

Staging cleanup is separate: those values only deploy via the release-please branch, so it should ride the next release (CCIE-7281).