### PR TITLE
fix: handle missing content-length when downloading compressed files

### DIFF
--- a/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
+++ b/client/python/cryoet_data_portal/src/cryoet_data_portal/_file_tools.py
@@ -43,7 +43,7 @@ def download_https(
 ):
     dest_path = get_destination_path(url, dest_path)
     fetch_request = requests.get(url, stream=True, headers={"User-agent": USER_AGENT})
-    total_size = int(fetch_request.headers["content-length"])
+    total_size = int(fetch_request.headers.get("content-length") or 0) or None
     block_size = 1024 * 512
     logger.info("Downloading %s to %s", url, dest_path)
     with tqdm(


### PR DESCRIPTION
`download_https` reads `content-length` with an unguarded dict lookup, only to size its progress bar. CloudFront gzips `application/json` responses between 1 KB and 10 MB, and a gzipped response is chunked, so it carries no `Content-Length` — the lookup raises `KeyError: 'content-length'` before any bytes are written. This breaks `Annotation.download_metadata()` and `Annotation.download()` for every annotation whose metadata was written since ingestion began setting `ContentType: application/json` in January 2025; sampling prod, 17 of 17 annotations fail, and `download()` leaves the data file on disk with no metadata next to it. `tqdm` accepts `total=None` and renders an indeterminate bar, so passing `None` when the header is absent is sufficient. Verified against prod with this patch applied: `download()` writes both files and the metadata parses (2964 bytes, 17 keys). `iter_content` already decodes the gzip, so file contents are unaffected. Not addressed here: the same function never calls `raise_for_status()`, so an error response would be written to disk as if it were file content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
