### PR TITLE
fix(frontend): link cell line ids out to Cellosaurus

### DIFF
--- a/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/components/InfoLink/InfoLink.test.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/components/InfoLink/InfoLink.test.tsx
@@ -1,7 +1,12 @@
 import { createRemixStub } from '@remix-run/testing'
 import { render, screen } from '@testing-library/react'
 
-import { NCBI, OBO, WORMBASE } from 'app/constants/datasetInfoLinks'
+import {
+  CELLOSAURUS,
+  NCBI,
+  OBO,
+  WORMBASE,
+} from 'app/constants/datasetInfoLinks'
 
 import { InfoLinkProps } from './InfoLink'
 
@@ -47,6 +52,17 @@ describe('<InfoLink />', () => {
     const link = screen.queryByRole('link', { name: value })
     expect(link).toBeVisible()
     expect(link).toHaveAttribute('href', `${NCBI}${rawId}`)
+  })
+
+  it('should render cellosaurus link', async () => {
+    // CVCL ids use an underscore, so they never matched the colon-based OBO pattern.
+    const id = 'CVCL_2959'
+    const value = 'HUVEC-C'
+    await renderInfoLink({ id, value })
+
+    const link = screen.queryByRole('link', { name: value })
+    expect(link).toBeVisible()
+    expect(link).toHaveAttribute('href', `${CELLOSAURUS}${id}`)
   })
 
   it('should render wormbase link', async () => {

--- a/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/components/InfoLink/InfoLink.tsx
+++ b/frontend/packages/data-portal/app/components/Dataset/SampleAndExperimentConditionsTable/components/InfoLink/InfoLink.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'app/components/Link'
 import {
+  CELLOSAURUS,
+  CELLOSAURUS_PATTERN,
   NCBI,
   NCBI_ONTOLOGY_PATTERN,
   OBO,
@@ -24,6 +26,8 @@ export function InfoLink({ value, id }: InfoLinkProps) {
       link = `${NCBI}${id}`
     } else if (id.match(NCBI_ONTOLOGY_PATTERN)) {
       link = `${NCBI}${id.replace('NCBITaxon:', '')}`
+    } else if (id.match(CELLOSAURUS_PATTERN)) {
+      link = `${CELLOSAURUS}${id}`
     } else if (id.match(WORMBASE_PATTERN)) {
       link = `${WORMBASE}${id.replaceAll(':', '_')}`
     } else if (id.match(OBO_PATTERN)) {

--- a/frontend/packages/data-portal/app/constants/datasetInfoLinks.ts
+++ b/frontend/packages/data-portal/app/constants/datasetInfoLinks.ts
@@ -1,8 +1,10 @@
 export const NCBI =
   'https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id='
+export const CELLOSAURUS = 'https://www.cellosaurus.org/'
 export const OBO = 'http://purl.obolibrary.org/obo/'
 export const WORMBASE = 'https://wormbase.org/species/c_elegans/strain/'
 
 export const NCBI_ONTOLOGY_PATTERN = /NCBITaxon:[0-9]+/
+export const CELLOSAURUS_PATTERN = /CVCL_[A-Z0-9]{4,}/
 export const OBO_PATTERN = /[a-zA-Z]+:[0-9]+/
 export const WORMBASE_PATTERN = /WBStrain[0-9]{8}/


### PR DESCRIPTION
## The bug

`InfoLink` tries four patterns in order, and `OBO_PATTERN` is `/[a-zA-Z]+:[0-9]+/` — it requires a **colon**. Cellosaurus ids use an underscore, so `CVCL_2959` fell through every branch and rendered as plain text.

| id | Before | After |
|---|---|---|
| `CVCL_2959` | **no link** | cellosaurus.org ✅ |
| `WBStrain00050783` | wormbase.org | unchanged |
| `CL:0002618` | purl.obolibrary.org | unchanged |
| `NCBITaxon:9606` | NCBI | unchanged |

Cell line was the only field in the sample table with no link-out.

The new branch sits before `WORMBASE_PATTERN`, and `CVCL_` cannot collide with the colon-based OBO pattern, so no existing id changes destination.

`https://www.cellosaurus.org/CVCL_2959` returns 200.

## Testing

One test added, matching the existing style. `InfoLink`: 7 passed (was 6).

Found while correcting 16 datasets whose `cell_strain` accession pointed at the wrong cell line (chanzuckerberg/cryoet-data-portal-backend#793) — the corrected ids would still have rendered unlinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qaMk9MQhg99QwbrzwYSY9
